### PR TITLE
feat: Implement WorkflowRegistry with DAG validation (#2)

### DIFF
--- a/SCRATCHPAD_2.md
+++ b/SCRATCHPAD_2.md
@@ -1,0 +1,136 @@
+# M1-2: Workflow Registry with DAG validation - #2
+
+## Issue Details
+- **Repository:** corpus-relica/reflex
+- **GitHub URL:** https://github.com/corpus-relica/reflex/issues/2
+- **State:** open
+- **Labels:** none
+- **Milestone:** M1: Core Types & Validation
+- **Assignees:** none
+- **Related Issues:**
+  - Depends on: #1 (M1-1: Core type definitions) — completed
+  - Blocks: #3 (M1-3: Test suite for validation)
+  - Dependency of: All subsequent milestones (M2-M6)
+
+## Description
+Implement `WorkflowRegistry` class:
+
+- `register(workflow)` — validates and stores
+- `get(id)`, `has(id)`, `list()`
+
+### Registration-time validation:
+- Topological sort (reject cycles)
+- Edge integrity (all `from`/`to` reference existing node IDs)
+- Entry node exists
+- At least one terminal node (no outgoing edges)
+- Invocation ref warnings (log if `invokes.workflowId` not yet registered)
+- Throw descriptive errors on validation failure
+
+## Acceptance Criteria
+- [ ] `WorkflowRegistry` class implemented in `src/registry.ts`
+- [ ] `register(workflow)` validates and stores workflows
+- [ ] `get(id)`, `has(id)`, `list()` retrieval methods work correctly
+- [ ] Cyclic graphs rejected with descriptive error
+- [ ] Invalid edge references rejected with descriptive error
+- [ ] Missing entry node rejected with descriptive error
+- [ ] No terminal nodes rejected with descriptive error
+- [ ] Invocation ref to unregistered workflow logs warning but doesn't reject
+- [ ] Descriptive errors on validation failure
+- [ ] TypeScript compiles without errors
+
+## Branch Strategy
+- **Base branch:** main
+- **Feature branch:** 2-workflow-registry-with-dag-validation
+- **Current branch:** main
+
+## Implementation Checklist
+
+### Setup
+- [x] Create feature branch from main
+
+### Implementation Tasks
+
+- [x] Create `src/registry.ts` with full WorkflowRegistry implementation
+  - Files affected: `src/registry.ts` (new file)
+  - Why: Single file, single commit — all validation logic is interdependent
+
+  Implementation details:
+
+  **Custom error class:**
+  - `WorkflowValidationError` extending Error
+  - Properties: `code` (enum), `workflowId`, `details`
+  - Error codes: `CYCLE_DETECTED`, `INVALID_EDGE`, `INVALID_ENTRY_NODE`, `NO_TERMINAL_NODES`, `DUPLICATE_WORKFLOW_ID`, `NODE_ID_MISMATCH`, `EMPTY_WORKFLOW`
+
+  **Registry class:**
+  - Private `Map<string, Workflow>` for storage
+  - `register(workflow)` — runs all validators, then stores
+  - `get(id)`, `has(id)`, `list()` — straightforward retrieval
+
+  **Validation order in register():**
+  1. Duplicate workflow ID check (fail fast)
+  2. Empty workflow check (no nodes)
+  3. Entry node exists in nodes dict
+  4. Node ID consistency (dict keys match node.id field)
+  5. Edge integrity (all from/to reference existing node IDs)
+  6. Terminal nodes exist (at least one with no outgoing edges)
+  7. Acyclicity (topological sort via Kahn's algorithm)
+  8. Invocation ref warnings (console.warn, non-blocking)
+  9. Store workflow
+
+  **Kahn's algorithm for cycle detection:**
+  - Build adjacency list + in-degree map from edges
+  - Process zero-in-degree nodes iteratively
+  - If not all nodes processed → cycle exists
+  - Report unprocessed nodes in error message
+
+### Quality Checks
+- [x] TypeScript compiles without errors (tsc --noEmit --strict)
+- [x] All methods and classes exported
+- [x] Cross-reference validation rules against DESIGN.md Section 3.3 — 0 discrepancies
+
+## Technical Notes
+
+### Architecture Considerations
+- This is the second foundational file — the engine (M4) will depend on it
+- Imports types from `./types` (created in #1)
+- No external dependencies
+- No package.json yet (deferred to M6-1)
+
+### Implementation Approach
+- Direct implementation from DESIGN.md Section 3.3
+- Custom `WorkflowValidationError` class for structured error handling
+- Kahn's algorithm for topological sort (O(V+E), standard approach)
+- `console.warn` for invocation ref warnings (sufficient for v-alpha)
+- Validate node ID consistency (dict keys match node.id) as bonus integrity check
+
+### Edge Cases
+- Empty workflow (no nodes) → reject
+- Single-node workflow (entry = terminal) → valid
+- Duplicate workflow ID → reject
+- Self-loop edge (from = to) → caught by cycle detection
+- Multiple terminal nodes → valid
+- Node with no incoming edges (besides entry) → valid
+
+### Assumptions Made
+- `console.warn` is acceptable for invocation ref warnings in v-alpha
+- Custom error class preferred over plain `Error` for structured handling
+- Node ID consistency check (dict key vs node.id) is worth including
+
+## Work Log
+
+### 2026-02-08 - Session 1
+- Created feature branch `2-workflow-registry-with-dag-validation` from main
+- Implemented `src/registry.ts` with full WorkflowRegistry class
+  - `WorkflowValidationError` custom error class with 7 error codes
+  - `register()` with 7 validation checks + invocation ref warnings
+  - `get()`, `has()`, `list()` retrieval methods
+  - Kahn's algorithm for cycle detection
+- TypeScript compiles clean (`tsc --noEmit --strict`)
+- Cross-referenced all 5 validation rules against DESIGN.md Section 3.3 — 0 discrepancies
+- All implementation tasks and quality checks complete
+- Ready for commit
+
+---
+**Generated:** 2026-02-08
+**By:** Issue Setup Skill
+**Source:** https://github.com/corpus-relica/reflex/issues/2

--- a/src/registry.ts
+++ b/src/registry.ts
@@ -1,0 +1,229 @@
+// Reflex — Workflow Registry with DAG Validation
+// Implements DESIGN.md Section 3.3
+
+import { Workflow } from './types';
+
+// ---------------------------------------------------------------------------
+// Validation Error
+// ---------------------------------------------------------------------------
+
+export type ValidationErrorCode =
+  | 'CYCLE_DETECTED'
+  | 'INVALID_EDGE'
+  | 'INVALID_ENTRY_NODE'
+  | 'NO_TERMINAL_NODES'
+  | 'DUPLICATE_WORKFLOW_ID'
+  | 'NODE_ID_MISMATCH'
+  | 'EMPTY_WORKFLOW';
+
+export class WorkflowValidationError extends Error {
+  public readonly code: ValidationErrorCode;
+  public readonly workflowId: string;
+  public readonly details: Record<string, unknown>;
+
+  constructor(
+    code: ValidationErrorCode,
+    workflowId: string,
+    message: string,
+    details: Record<string, unknown> = {},
+  ) {
+    super(message);
+    this.name = 'WorkflowValidationError';
+    this.code = code;
+    this.workflowId = workflowId;
+    this.details = details;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Workflow Registry
+// ---------------------------------------------------------------------------
+
+export class WorkflowRegistry {
+  private readonly workflows = new Map<string, Workflow>();
+
+  /**
+   * Validate and register a workflow.
+   * Throws WorkflowValidationError on structural problems.
+   * Logs a warning (but does not reject) for unregistered invocation refs.
+   */
+  register(workflow: Workflow): void {
+    this.validateNoDuplicate(workflow);
+    this.validateNotEmpty(workflow);
+    this.validateEntryNode(workflow);
+    this.validateNodeIdConsistency(workflow);
+    this.validateEdgeIntegrity(workflow);
+    this.validateTerminalNodes(workflow);
+    this.validateAcyclic(workflow);
+    this.warnInvocationRefs(workflow);
+
+    this.workflows.set(workflow.id, workflow);
+  }
+
+  get(id: string): Workflow | undefined {
+    return this.workflows.get(id);
+  }
+
+  has(id: string): boolean {
+    return this.workflows.has(id);
+  }
+
+  list(): string[] {
+    return Array.from(this.workflows.keys());
+  }
+
+  // -------------------------------------------------------------------------
+  // Validation — private methods
+  // -------------------------------------------------------------------------
+
+  private validateNoDuplicate(workflow: Workflow): void {
+    if (this.workflows.has(workflow.id)) {
+      throw new WorkflowValidationError(
+        'DUPLICATE_WORKFLOW_ID',
+        workflow.id,
+        `Workflow '${workflow.id}' is already registered`,
+      );
+    }
+  }
+
+  private validateNotEmpty(workflow: Workflow): void {
+    if (Object.keys(workflow.nodes).length === 0) {
+      throw new WorkflowValidationError(
+        'EMPTY_WORKFLOW',
+        workflow.id,
+        `Workflow '${workflow.id}' has no nodes`,
+      );
+    }
+  }
+
+  private validateEntryNode(workflow: Workflow): void {
+    if (!(workflow.entry in workflow.nodes)) {
+      throw new WorkflowValidationError(
+        'INVALID_ENTRY_NODE',
+        workflow.id,
+        `Workflow '${workflow.id}' declares entry node '${workflow.entry}' which does not exist in nodes`,
+        { entry: workflow.entry },
+      );
+    }
+  }
+
+  private validateNodeIdConsistency(workflow: Workflow): void {
+    for (const [key, node] of Object.entries(workflow.nodes)) {
+      if (key !== node.id) {
+        throw new WorkflowValidationError(
+          'NODE_ID_MISMATCH',
+          workflow.id,
+          `Workflow '${workflow.id}': node dict key '${key}' does not match node.id '${node.id}'`,
+          { key, nodeId: node.id },
+        );
+      }
+    }
+  }
+
+  private validateEdgeIntegrity(workflow: Workflow): void {
+    const nodeIds = new Set(Object.keys(workflow.nodes));
+
+    for (const edge of workflow.edges) {
+      if (!nodeIds.has(edge.from)) {
+        throw new WorkflowValidationError(
+          'INVALID_EDGE',
+          workflow.id,
+          `Workflow '${workflow.id}': edge '${edge.id}' references non-existent source node '${edge.from}'`,
+          { edgeId: edge.id, field: 'from', nodeId: edge.from },
+        );
+      }
+      if (!nodeIds.has(edge.to)) {
+        throw new WorkflowValidationError(
+          'INVALID_EDGE',
+          workflow.id,
+          `Workflow '${workflow.id}': edge '${edge.id}' references non-existent target node '${edge.to}'`,
+          { edgeId: edge.id, field: 'to', nodeId: edge.to },
+        );
+      }
+    }
+  }
+
+  private validateTerminalNodes(workflow: Workflow): void {
+    const nodesWithOutgoing = new Set<string>();
+    for (const edge of workflow.edges) {
+      nodesWithOutgoing.add(edge.from);
+    }
+
+    const terminalNodes = Object.keys(workflow.nodes).filter(
+      (id) => !nodesWithOutgoing.has(id),
+    );
+
+    if (terminalNodes.length === 0) {
+      throw new WorkflowValidationError(
+        'NO_TERMINAL_NODES',
+        workflow.id,
+        `Workflow '${workflow.id}' has no terminal nodes (every node has outgoing edges)`,
+      );
+    }
+  }
+
+  /**
+   * Validate acyclicity using Kahn's algorithm (topological sort).
+   * O(V + E) — standard approach for DAG validation.
+   */
+  private validateAcyclic(workflow: Workflow): void {
+    const nodeIds = Object.keys(workflow.nodes);
+    const inDegree = new Map<string, number>();
+    const adjList = new Map<string, string[]>();
+
+    // Initialize
+    for (const id of nodeIds) {
+      inDegree.set(id, 0);
+      adjList.set(id, []);
+    }
+
+    // Build graph from edges
+    for (const edge of workflow.edges) {
+      adjList.get(edge.from)!.push(edge.to);
+      inDegree.set(edge.to, inDegree.get(edge.to)! + 1);
+    }
+
+    // Kahn's algorithm: process nodes with zero in-degree
+    const queue: string[] = [];
+    for (const [id, degree] of inDegree) {
+      if (degree === 0) queue.push(id);
+    }
+
+    const sorted: string[] = [];
+    while (queue.length > 0) {
+      const node = queue.shift()!;
+      sorted.push(node);
+
+      for (const neighbor of adjList.get(node)!) {
+        const newDegree = inDegree.get(neighbor)! - 1;
+        inDegree.set(neighbor, newDegree);
+        if (newDegree === 0) queue.push(neighbor);
+      }
+    }
+
+    // If not all nodes were processed, a cycle exists
+    if (sorted.length !== nodeIds.length) {
+      const nodesInCycle = nodeIds.filter((id) => !sorted.includes(id));
+      throw new WorkflowValidationError(
+        'CYCLE_DETECTED',
+        workflow.id,
+        `Workflow '${workflow.id}' contains a cycle involving nodes: ${nodesInCycle.join(', ')}`,
+        { nodesInCycle },
+      );
+    }
+  }
+
+  /**
+   * Warn (but don't reject) if invocation refs point to unregistered workflows.
+   * The target workflow may be registered later.
+   */
+  private warnInvocationRefs(workflow: Workflow): void {
+    for (const [nodeId, node] of Object.entries(workflow.nodes)) {
+      if (node.invokes && !this.workflows.has(node.invokes.workflowId)) {
+        console.warn(
+          `Workflow '${workflow.id}', node '${nodeId}': invokes workflow '${node.invokes.workflowId}' which is not yet registered`,
+        );
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
Implements the `WorkflowRegistry` class — the validated storage layer for workflow
definitions. This is the second foundational component of Reflex (after core types),
enabling registration-time structural validation of workflow DAGs.

## Issue Resolution
Closes #2

Implements all requirements from DESIGN.md Section 3.3:
- `register(workflow)` with full DAG validation
- `get(id)`, `has(id)`, `list()` retrieval methods
- All 5 specified validation rules

## Key Changes
- **`src/registry.ts`** — New file with `WorkflowRegistry` class and `WorkflowValidationError`
- Registration-time validation:
  - Topological sort (Kahn's algorithm) for cycle detection
  - Edge integrity (all `from`/`to` reference existing nodes)
  - Entry node existence check
  - Terminal node validation (at least one with no outgoing edges)
  - Invocation ref warnings (`console.warn`, non-blocking)
- Additional defensive checks: duplicate workflow ID, empty workflow, node ID consistency

## Implementation Notes
- `WorkflowValidationError` custom error class with structured error codes for
  programmatic handling
- Kahn's algorithm chosen for topological sort — O(V+E), standard approach
- `console.warn` for invocation ref warnings (sufficient for v-alpha; can be
  upgraded to logger interface post-alpha)
- Node ID consistency check (dict keys match `node.id`) added as bonus integrity
  validation beyond the spec

## Testing
- TypeScript compiles clean (`tsc --noEmit --strict`)
- Cross-referenced all validation rules against DESIGN.md Section 3.3 — 0 discrepancies
- Unit test suite will be added in #3 (M1-3: Test suite for validation)

## Checklist
- [x] Code follows project conventions
- [x] Changes are atomic and reviewable
- [ ] Tests added/updated (deferred to #3)