### PR TITLE
feat: Blackboard write + append-only enforcement (#5)

### DIFF
--- a/src/blackboard.test.ts
+++ b/src/blackboard.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
-import { ScopedBlackboardReader } from './blackboard';
-import { BlackboardEntry } from './types';
+import { ScopedBlackboardReader, ScopedBlackboard } from './blackboard';
+import { BlackboardEntry, BlackboardSource, BlackboardWrite } from './types';
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -275,6 +275,209 @@ describe('ScopedBlackboardReader', () => {
       const loc = reader.local();
       loc.pop();
       expect(reader.local()).toHaveLength(1);
+    });
+  });
+});
+
+// ===========================================================================
+// ScopedBlackboard (write side)
+// ===========================================================================
+
+describe('ScopedBlackboard', () => {
+  const source: BlackboardSource = {
+    workflowId: 'wf-1',
+    nodeId: 'node-A',
+    stackDepth: 0,
+  };
+
+  // -----------------------------------------------------------------------
+  // append() basics
+  // -----------------------------------------------------------------------
+
+  describe('append()', () => {
+    it('creates entries with correct key and value', () => {
+      const bb = new ScopedBlackboard();
+      bb.append([{ key: 'color', value: 'blue' }], source);
+      const entries = bb.getEntries();
+      expect(entries).toHaveLength(1);
+      expect(entries[0].key).toBe('color');
+      expect(entries[0].value).toBe('blue');
+    });
+
+    it('attaches source metadata to every entry', () => {
+      const bb = new ScopedBlackboard();
+      bb.append([{ key: 'x', value: 1 }], source);
+      const e = bb.getEntries()[0];
+      expect(e.source.workflowId).toBe('wf-1');
+      expect(e.source.nodeId).toBe('node-A');
+      expect(e.source.stackDepth).toBe(0);
+    });
+
+    it('attaches a numeric timestamp to every entry', () => {
+      const bb = new ScopedBlackboard();
+      const before = Date.now();
+      bb.append([{ key: 'x', value: 1 }], source);
+      const after = Date.now();
+      const ts = bb.getEntries()[0].timestamp;
+      expect(ts).toBeGreaterThanOrEqual(before);
+      expect(ts).toBeLessThanOrEqual(after);
+    });
+
+    it('gives all entries in one call the same timestamp and source', () => {
+      const bb = new ScopedBlackboard();
+      const writes: BlackboardWrite[] = [
+        { key: 'a', value: 1 },
+        { key: 'b', value: 2 },
+        { key: 'c', value: 3 },
+      ];
+      bb.append(writes, source);
+      const entries = bb.getEntries();
+      expect(entries).toHaveLength(3);
+      const ts = entries[0].timestamp;
+      for (const e of entries) {
+        expect(e.timestamp).toBe(ts);
+        expect(e.source).toBe(source);
+      }
+    });
+
+    it('returns the newly created entries', () => {
+      const bb = new ScopedBlackboard();
+      const result = bb.append([{ key: 'x', value: 42 }], source);
+      expect(result).toHaveLength(1);
+      expect(result[0].key).toBe('x');
+      expect(result[0].value).toBe(42);
+      expect(result[0].source).toBe(source);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Append-only invariant
+  // -----------------------------------------------------------------------
+
+  describe('append-only invariant', () => {
+    it('entries accumulate across multiple append() calls', () => {
+      const bb = new ScopedBlackboard();
+      bb.append([{ key: 'a', value: 1 }], source);
+      bb.append([{ key: 'b', value: 2 }], source);
+      bb.append([{ key: 'c', value: 3 }], source);
+      expect(bb.getEntries()).toHaveLength(3);
+    });
+
+    it('existing entries are unchanged after a new append', () => {
+      const bb = new ScopedBlackboard();
+      bb.append([{ key: 'a', value: 1 }], source);
+      const first = bb.getEntries()[0];
+      bb.append([{ key: 'b', value: 2 }], source);
+      const entries = bb.getEntries();
+      expect(entries[0].key).toBe(first.key);
+      expect(entries[0].value).toBe(first.value);
+      expect(entries[0].timestamp).toBe(first.timestamp);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Same-key shadowing (via reader integration)
+  // -----------------------------------------------------------------------
+
+  describe('same-key shadowing', () => {
+    it('reader.get() returns the latest value for a shadowed key', () => {
+      const bb = new ScopedBlackboard();
+      bb.append([{ key: 'color', value: 'blue' }], source);
+      bb.append([{ key: 'color', value: 'red' }], source);
+      const reader = bb.reader();
+      expect(reader.get('color')).toBe('red');
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // getEntries()
+  // -----------------------------------------------------------------------
+
+  describe('getEntries()', () => {
+    it('returns current entries reflecting all appends', () => {
+      const bb = new ScopedBlackboard();
+      bb.append([{ key: 'x', value: 1 }], source);
+      bb.append([{ key: 'y', value: 2 }], source);
+      const entries = bb.getEntries();
+      expect(entries).toHaveLength(2);
+      expect(entries[0].key).toBe('x');
+      expect(entries[1].key).toBe('y');
+    });
+
+    it('returns a copy — mutations do not affect internal state', () => {
+      const bb = new ScopedBlackboard();
+      bb.append([{ key: 'x', value: 1 }], source);
+      const snapshot = bb.getEntries();
+      // Mutate the returned array
+      (snapshot as BlackboardEntry[]).push(entry('hack', 99));
+      expect(bb.getEntries()).toHaveLength(1);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // reader()
+  // -----------------------------------------------------------------------
+
+  describe('reader()', () => {
+    it('constructs a working ScopedBlackboardReader', () => {
+      const bb = new ScopedBlackboard();
+      bb.append([{ key: 'color', value: 'green' }], source);
+      const reader = bb.reader();
+      expect(reader.get('color')).toBe('green');
+      expect(reader.has('color')).toBe(true);
+      expect(reader.keys()).toContain('color');
+    });
+
+    it('includes parent scopes in the reader', () => {
+      const bb = new ScopedBlackboard();
+      const parentEntries = [entry('origin', 'parent-value')];
+      const reader = bb.reader([parentEntries]);
+      expect(reader.get('origin')).toBe('parent-value');
+    });
+
+    it('local scope reflects writes, shadowing parent values', () => {
+      const bb = new ScopedBlackboard();
+      const parentEntries = [entry('color', 'parent-blue')];
+      bb.append([{ key: 'color', value: 'local-red' }], source);
+      const reader = bb.reader([parentEntries]);
+      expect(reader.get('color')).toBe('local-red');
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Empty blackboard
+  // -----------------------------------------------------------------------
+
+  describe('empty blackboard', () => {
+    it('getEntries() returns empty array', () => {
+      const bb = new ScopedBlackboard();
+      expect(bb.getEntries()).toEqual([]);
+    });
+
+    it('reader().get() returns undefined', () => {
+      const bb = new ScopedBlackboard();
+      expect(bb.reader().get('anything')).toBeUndefined();
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Constructor with seed entries
+  // -----------------------------------------------------------------------
+
+  describe('constructor with seed entries', () => {
+    it('initializes with provided entries', () => {
+      const seed = [entry('x', 1), entry('y', 2)];
+      const bb = new ScopedBlackboard(seed);
+      expect(bb.getEntries()).toHaveLength(2);
+      expect(bb.reader().get('x')).toBe(1);
+      expect(bb.reader().get('y')).toBe(2);
+    });
+
+    it('append adds to seed entries', () => {
+      const seed = [entry('x', 1)];
+      const bb = new ScopedBlackboard(seed);
+      bb.append([{ key: 'y', value: 2 }], source);
+      expect(bb.getEntries()).toHaveLength(2);
     });
   });
 });


### PR DESCRIPTION
## Summary
Implements the write side of the scoped blackboard system, completing M2-2.

Closes #5

## Key Changes
- `ScopedBlackboard` class in `src/blackboard.ts` — append-only container for a single scope's entries
  - `append(writes, source)` converts `BlackboardWrite[]` to full `BlackboardEntry[]` with source metadata and timestamp
  - `getEntries()` returns defensive copy of local entries
  - `reader(parentScopes?)` constructs a `ScopedBlackboardReader` for the scope chain
- 17 new tests in `src/blackboard.test.ts` (62 total passing)

## Implementation Notes
- Append-only enforced by API surface — no delete, clear, or set methods exist
- All entries from a single `append()` call share the same timestamp and source (one decision = one batch)
- `getEntries()` returns a copy to prevent external mutation bypassing the append-only invariant
- Constructor accepts optional seed entries for state restoration

## Testing
- 17 new tests covering: append basics (5), append-only invariant (2), same-key shadowing (1), getEntries (2), reader integration (3), empty blackboard (2), constructor seeding (2)
- All 62 project tests pass (45 blackboard + 17 registry)
- TypeScript compiles clean