### PR TITLE
feat(guards): Add custom guard evaluator and unified dispatcher (#8)

### DIFF
--- a/src/guards.ts
+++ b/src/guards.ts
@@ -1,7 +1,25 @@
 // Reflex — Guard Evaluation
 // Implements DESIGN.md Section 2.8
 
-import { BuiltinGuard, BlackboardReader } from './types';
+import { BuiltinGuard, CustomGuard, Guard, BlackboardReader } from './types';
+
+// ---------------------------------------------------------------------------
+// Guard Result Type
+// ---------------------------------------------------------------------------
+
+/**
+ * Discriminated result from guard evaluation.
+ *
+ * - `{ ok: true, passed }` — guard evaluated successfully, `passed` is the result
+ * - `{ ok: false, error }` — guard threw during evaluation (engine error)
+ *
+ * This is an evaluation-layer type, not a domain type — it lives here rather
+ * than in types.ts because it is consumed only by the guard subsystem and the
+ * engine's edge-filtering logic.
+ */
+export type GuardResult =
+  | { ok: true; passed: boolean }
+  | { ok: false; error: unknown };
 
 // ---------------------------------------------------------------------------
 // Built-in Guard Evaluator
@@ -31,4 +49,56 @@ export function evaluateBuiltinGuard(
       throw new Error(`Unknown guard type: ${_exhaustive}`);
     }
   }
+}
+
+// ---------------------------------------------------------------------------
+// Custom Guard Evaluator
+// ---------------------------------------------------------------------------
+
+/**
+ * Evaluate a custom guard against the scoped blackboard.
+ *
+ * Calls the guard's `evaluate` function with the BlackboardReader.
+ * If the function throws, the error is caught and returned as
+ * `{ ok: false, error }` — the caller (engine) treats this as an
+ * engine error, not a valid transition.
+ *
+ * Contract: custom guards SHOULD be total, terminating, and side-effect free.
+ * Violations are caught here but indicate a bug in the guard, not in Reflex.
+ */
+export function evaluateCustomGuard(
+  guard: CustomGuard,
+  blackboard: BlackboardReader,
+): GuardResult {
+  try {
+    const passed = guard.evaluate(blackboard);
+    return { ok: true, passed };
+  } catch (error) {
+    return { ok: false, error };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Unified Guard Evaluator
+// ---------------------------------------------------------------------------
+
+/**
+ * Evaluate any guard (built-in or custom) against the scoped blackboard.
+ *
+ * Dispatches to `evaluateBuiltinGuard` or `evaluateCustomGuard` based on
+ * the guard's `type` discriminant. Returns a `GuardResult` in both cases
+ * so the caller has a uniform API.
+ *
+ * Built-in guards are safe by construction (exhaustive switch, no I/O) and
+ * wrapped directly in `{ ok: true }`. Custom guards go through try/catch.
+ */
+export function evaluateGuard(
+  guard: Guard,
+  blackboard: BlackboardReader,
+): GuardResult {
+  if (guard.type === 'custom') {
+    return evaluateCustomGuard(guard, blackboard);
+  }
+  const passed = evaluateBuiltinGuard(guard, blackboard);
+  return { ok: true, passed };
 }


### PR DESCRIPTION
## Summary
Implements M3-2: Custom guard support — the second piece of the M3 Guard Evaluation milestone.

Closes #8

## Key Changes
- `GuardResult` discriminated union type for type-safe error propagation
  (`{ ok: true; passed: boolean }` vs `{ ok: false; error: unknown }`)
- `evaluateCustomGuard()` — calls `CustomGuard.evaluate` with scoped
  `BlackboardReader`, wraps in try/catch per DESIGN.md Section 2.8
- `evaluateGuard()` — unified dispatcher routing built-in and custom guards
  through a single API, ready for M3-3 edge filtering consumption
- 14 new tests covering custom guard evaluation and unified dispatch

## Implementation Notes
- `GuardResult` lives in `guards.ts` (evaluation-layer type, not a domain type)
- Existing `evaluateBuiltinGuard()` keeps its `boolean` return — wrapped
  internally by `evaluateGuard()` for uniform `GuardResult` API
- Built-in guards are safe by construction (exhaustive switch, no I/O);
  only custom guards need the try/catch path

## Testing
- 14 new tests: 6 for `evaluateCustomGuard`, 8 for `evaluateGuard` dispatch
- All 115 tests pass (29 guards + 17 registry + 69 blackboard)
- Existing 15 built-in guard tests unchanged