### PR TITLE
feat(guards): Add edge filtering with guard evaluation (M3-3)

### DIFF
--- a/src/guards.ts
+++ b/src/guards.ts
@@ -1,7 +1,7 @@
 // Reflex — Guard Evaluation
 // Implements DESIGN.md Section 2.8
 
-import { BuiltinGuard, CustomGuard, Guard, BlackboardReader } from './types';
+import { BuiltinGuard, CustomGuard, Guard, Edge, BlackboardReader } from './types';
 
 // ---------------------------------------------------------------------------
 // Guard Result Type
@@ -101,4 +101,58 @@ export function evaluateGuard(
   }
   const passed = evaluateBuiltinGuard(guard, blackboard);
   return { ok: true, passed };
+}
+
+// ---------------------------------------------------------------------------
+// Edge Filtering
+// ---------------------------------------------------------------------------
+
+/**
+ * Result of filtering outgoing edges for a node.
+ *
+ * - `{ ok: true, edges }` — all guards evaluated successfully, `edges` is the valid set
+ * - `{ ok: false, error }` — a guard threw during evaluation (engine error)
+ *
+ * Follows the same discriminated union pattern as `GuardResult`.
+ */
+export type FilterEdgesResult =
+  | { ok: true; edges: Edge[] }
+  | { ok: false; error: unknown };
+
+/**
+ * Compute valid outgoing edges for a node given the current blackboard.
+ *
+ * 1. Collects outgoing edges (where `edge.from === nodeId`)
+ * 2. Evaluates each edge's guard against the scoped blackboard
+ * 3. Edges with no guard are always valid
+ * 4. Short-circuits on the first guard error (`{ ok: false }`)
+ *
+ * This is the composition point between guard evaluation (M3-1/M3-2) and
+ * the execution engine (M4). The engine calls this to determine which
+ * edges are available for the decision agent to choose from.
+ */
+export function filterEdges(
+  nodeId: string,
+  edges: Edge[],
+  blackboard: BlackboardReader,
+): FilterEdgesResult {
+  const outgoing = edges.filter((e) => e.from === nodeId);
+  const valid: Edge[] = [];
+
+  for (const edge of outgoing) {
+    if (!edge.guard) {
+      valid.push(edge);
+      continue;
+    }
+
+    const result = evaluateGuard(edge.guard, blackboard);
+    if (!result.ok) {
+      return { ok: false, error: result.error };
+    }
+    if (result.passed) {
+      valid.push(edge);
+    }
+  }
+
+  return { ok: true, edges: valid };
 }


### PR DESCRIPTION
## Summary
Implements edge filtering — the composition point between guard evaluation (M3-1/M3-2) and the execution engine (M4). Given a node and the current blackboard, computes the set of valid outgoing edges by evaluating each edge's guard.

Closes #9

## Key Changes
- `FilterEdgesResult` discriminated union type (matches `GuardResult` pattern)
- `filterEdges(nodeId, edges, blackboard)` function in `src/guards.ts`
  - Filters to outgoing edges for the node
  - Evaluates guards via `evaluateGuard` against scoped blackboard
  - Edges with no guard are always valid
  - Short-circuits on first guard error (consistent with DESIGN.md §3.4)
- 11 new tests in `src/guards.test.ts` covering:
  - Basic cases (no guards, no edges, all fail)
  - Fan-out with mixed guard results
  - Error propagation and short-circuit behavior
  - Cross-scope blackboard reads
  - NodeId filtering

## Testing
- All 126 tests pass (3 test files, 0 failures)
- `npx vitest run` clean