### PR TITLE
feat: Add physical object modeling workflow set (#19)

### DIFF
--- a/src/examples/phys-obj-workflows.test.ts
+++ b/src/examples/phys-obj-workflows.test.ts
@@ -1,0 +1,235 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { ReflexEngine } from '../engine';
+import { WorkflowRegistry } from '../registry';
+import { createRuleAgent, RuleAgent } from './rule-agent';
+import {
+  definePhysicalObjectWorkflow,
+  definePartObjectWorkflow,
+  registerPhysObjWorkflows,
+} from './phys-obj-workflows';
+import { Workflow, EngineEvent } from '../types';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Create a "no-part" variant by spreading and removing needsPart from writes. */
+function makeNoPartWorkflow(): Workflow {
+  return {
+    ...definePhysicalObjectWorkflow,
+    id: 'define-physical-object-no-part',
+    nodes: {
+      ...definePhysicalObjectWorkflow.nodes,
+      BASIC_DATA: {
+        ...definePhysicalObjectWorkflow.nodes['BASIC_DATA'],
+        spec: {
+          writes: [{ key: 'conceptName', value: 'Steel Pipe' }],
+          edge: 'e-basic-branch',
+        },
+      },
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('Physical Object Workflows', () => {
+  let agent: RuleAgent;
+  let registry: WorkflowRegistry;
+
+  beforeEach(() => {
+    agent = createRuleAgent();
+    registry = new WorkflowRegistry();
+  });
+
+  // -------------------------------------------------------------------------
+  // With part (invocation path)
+  // -------------------------------------------------------------------------
+
+  describe('define-physical-object — with part', () => {
+    it('runs to completion with all expected blackboard values', async () => {
+      registerPhysObjWorkflows(registry);
+      const engine = new ReflexEngine(registry, agent);
+      await engine.init('define-physical-object');
+
+      const result = await engine.run();
+
+      expect(result.status).toBe('completed');
+      expect(engine.blackboard().get('workflowType')).toBe('define-physical-object');
+      expect(engine.blackboard().get('conceptName')).toBe('Steel Pipe');
+      expect(engine.blackboard().get('Part Concept')).toBe('Aluminum Housing');
+      expect(engine.blackboard().get('specRelation')).toBe(
+        'Steel Pipe specializes Physical Object',
+      );
+      expect(engine.blackboard().get('status')).toBe('physical-object-defined');
+    });
+
+    it('returnMap promotes partConcept as Part Concept in parent', async () => {
+      registerPhysObjWorkflows(registry);
+      const engine = new ReflexEngine(registry, agent);
+      await engine.init('define-physical-object');
+
+      await engine.run();
+
+      // Part Concept comes from returnMap, partConcept is the child's local key
+      expect(engine.blackboard().get('Part Concept')).toBe('Aluminum Housing');
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Without part (skip invocation)
+  // -------------------------------------------------------------------------
+
+  describe('define-physical-object — without part', () => {
+    it('takes the spec-compose path when needsPart is absent', async () => {
+      const noPartWorkflow = makeNoPartWorkflow();
+      registry.register(definePartObjectWorkflow);
+      registry.register(noPartWorkflow);
+      const engine = new ReflexEngine(registry, agent);
+      await engine.init('define-physical-object-no-part');
+
+      const result = await engine.run();
+
+      expect(result.status).toBe('completed');
+      expect(engine.blackboard().get('specRelation')).toBe(
+        'Steel Pipe specializes Physical Object',
+      );
+      expect(engine.blackboard().get('status')).toBe('physical-object-defined');
+    });
+
+    it('has no Part Concept when sub-workflow is skipped', async () => {
+      const noPartWorkflow = makeNoPartWorkflow();
+      registry.register(definePartObjectWorkflow);
+      registry.register(noPartWorkflow);
+      const engine = new ReflexEngine(registry, agent);
+      await engine.init('define-physical-object-no-part');
+
+      await engine.run();
+
+      expect(engine.blackboard().has('Part Concept')).toBe(false);
+      expect(engine.blackboard().has('partConcept')).toBe(false);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Stack operations
+  // -------------------------------------------------------------------------
+
+  describe('stack operations', () => {
+    it('stack depth is 1 when sub-workflow is active', async () => {
+      registerPhysObjWorkflows(registry);
+      const engine = new ReflexEngine(registry, agent);
+      await engine.init('define-physical-object');
+
+      let maxStackDepth = 0;
+      engine.on('workflow:push', () => {
+        maxStackDepth = Math.max(maxStackDepth, engine.stack().length);
+      });
+
+      await engine.run();
+
+      expect(maxStackDepth).toBe(1);
+    });
+
+    it('stack is empty after sub-workflow pops', async () => {
+      registerPhysObjWorkflows(registry);
+      const engine = new ReflexEngine(registry, agent);
+      await engine.init('define-physical-object');
+
+      let stackAfterPop = -1;
+      engine.on('workflow:pop', () => {
+        stackAfterPop = engine.stack().length;
+      });
+
+      await engine.run();
+
+      expect(stackAfterPop).toBe(0);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Scoped blackboard
+  // -------------------------------------------------------------------------
+
+  describe('scoped blackboard', () => {
+    it('child workflow can read parent conceptName via scoped blackboard', async () => {
+      registerPhysObjWorkflows(registry);
+
+      // Use a spy agent that captures the blackboard at PART_BASIC_DATA
+      let childSawConceptName = false;
+      const spyAgent = createRuleAgent();
+      const originalResolve = spyAgent.resolve.bind(spyAgent);
+      spyAgent.resolve = async (ctx) => {
+        if (ctx.node.id === 'PART_BASIC_DATA') {
+          childSawConceptName = ctx.blackboard.has('conceptName');
+        }
+        return originalResolve(ctx);
+      };
+
+      const engine = new ReflexEngine(registry, spyAgent);
+      await engine.init('define-physical-object');
+      await engine.run();
+
+      expect(childSawConceptName).toBe(true);
+    });
+
+    it('parent conceptName is not in child local scope', async () => {
+      registerPhysObjWorkflows(registry);
+
+      let conceptNameInLocal = true;
+      const spyAgent = createRuleAgent();
+      const originalResolve = spyAgent.resolve.bind(spyAgent);
+      spyAgent.resolve = async (ctx) => {
+        if (ctx.node.id === 'PART_BASIC_DATA') {
+          const localKeys = ctx.blackboard.local().map((e) => e.key);
+          conceptNameInLocal = localKeys.includes('conceptName');
+        }
+        return originalResolve(ctx);
+      };
+
+      const engine = new ReflexEngine(registry, spyAgent);
+      await engine.init('define-physical-object');
+      await engine.run();
+
+      expect(conceptNameInLocal).toBe(false);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Event trace
+  // -------------------------------------------------------------------------
+
+  describe('event trace', () => {
+    it('emits exactly one push and one pop for the with-part path', async () => {
+      registerPhysObjWorkflows(registry);
+      const engine = new ReflexEngine(registry, agent);
+      await engine.init('define-physical-object');
+
+      const events: EngineEvent[] = [];
+      engine.on('workflow:push', () => events.push('workflow:push'));
+      engine.on('workflow:pop', () => events.push('workflow:pop'));
+
+      await engine.run();
+
+      expect(events).toEqual(['workflow:push', 'workflow:pop']);
+    });
+
+    it('emits no push/pop on the without-part path', async () => {
+      const noPartWorkflow = makeNoPartWorkflow();
+      registry.register(definePartObjectWorkflow);
+      registry.register(noPartWorkflow);
+      const engine = new ReflexEngine(registry, agent);
+      await engine.init('define-physical-object-no-part');
+
+      const events: EngineEvent[] = [];
+      engine.on('workflow:push', () => events.push('workflow:push'));
+      engine.on('workflow:pop', () => events.push('workflow:pop'));
+
+      await engine.run();
+
+      expect(events).toEqual([]);
+    });
+  });
+});

--- a/src/examples/phys-obj-workflows.ts
+++ b/src/examples/phys-obj-workflows.ts
@@ -1,0 +1,117 @@
+// Reflex — Physical Object Modeling Workflow Set
+// M5-2: Simplified translation of the Relica PhysObjMachine into Reflex format.
+//
+// Two workflows:
+//   1. define-part-object   — linear sub-workflow (3 nodes)
+//   2. define-physical-object — root workflow with fan-out + invocation (6 nodes)
+//
+// Both are designed for the RuleAgent from M5-1.
+
+import { Workflow } from '../types';
+import { WorkflowRegistry } from '../registry';
+import { RuleSpec } from './rule-agent';
+
+// ---------------------------------------------------------------------------
+// Helper — build a node with a RuleSpec
+// ---------------------------------------------------------------------------
+
+function ruleNode(id: string, spec: RuleSpec) {
+  return { id, spec };
+}
+
+// ---------------------------------------------------------------------------
+// Sub-workflow: define-part-object (3 nodes, linear)
+// ---------------------------------------------------------------------------
+
+export const definePartObjectWorkflow: Workflow = {
+  id: 'define-part-object',
+  entry: 'PART_CLASSIFY',
+  nodes: {
+    PART_CLASSIFY: ruleNode('PART_CLASSIFY', {
+      writes: [{ key: 'partContext', value: 'Physical Object — Part' }],
+    }),
+    PART_BASIC_DATA: ruleNode('PART_BASIC_DATA', {
+      writes: [{ key: 'partConcept', value: 'Aluminum Housing' }],
+    }),
+    PART_DONE: ruleNode('PART_DONE', {
+      complete: true,
+      writes: [{ key: 'partStatus', value: 'complete' }],
+    }),
+  },
+  edges: [
+    { id: 'e-part-classify-basic', from: 'PART_CLASSIFY', to: 'PART_BASIC_DATA', event: 'NEXT' },
+    { id: 'e-part-basic-done', from: 'PART_BASIC_DATA', to: 'PART_DONE', event: 'NEXT' },
+  ],
+};
+
+// ---------------------------------------------------------------------------
+// Root workflow: define-physical-object (6 nodes)
+// ---------------------------------------------------------------------------
+
+export const definePhysicalObjectWorkflow: Workflow = {
+  id: 'define-physical-object',
+  entry: 'CLASSIFY',
+  nodes: {
+    CLASSIFY: ruleNode('CLASSIFY', {
+      writes: [{ key: 'workflowType', value: 'define-physical-object' }],
+      edge: 'e-classify-basic',
+    }),
+    BASIC_DATA: ruleNode('BASIC_DATA', {
+      writes: [
+        { key: 'conceptName', value: 'Steel Pipe' },
+        { key: 'needsPart', value: true },
+      ],
+      edge: 'e-basic-branch',
+    }),
+    BRANCH: ruleNode('BRANCH', {
+      edge: ['e-branch-to-part', 'e-branch-to-spec'],
+    }),
+    DEFINE_PART: {
+      id: 'DEFINE_PART',
+      spec: {},
+      invokes: {
+        workflowId: 'define-part-object',
+        returnMap: [{ parentKey: 'Part Concept', childKey: 'partConcept' }],
+      },
+    },
+    SPEC_COMPOSE: ruleNode('SPEC_COMPOSE', {
+      writes: [
+        { key: 'specRelation', value: 'Steel Pipe specializes Physical Object' },
+      ],
+    }),
+    DONE: ruleNode('DONE', {
+      complete: true,
+      writes: [{ key: 'status', value: 'physical-object-defined' }],
+    }),
+  },
+  edges: [
+    { id: 'e-classify-basic', from: 'CLASSIFY', to: 'BASIC_DATA', event: 'NEXT' },
+    { id: 'e-basic-branch', from: 'BASIC_DATA', to: 'BRANCH', event: 'NEXT' },
+    {
+      id: 'e-branch-to-part',
+      from: 'BRANCH',
+      to: 'DEFINE_PART',
+      event: 'DEFINE_PART',
+      guard: { type: 'exists', key: 'needsPart' },
+    },
+    {
+      id: 'e-branch-to-spec',
+      from: 'BRANCH',
+      to: 'SPEC_COMPOSE',
+      event: 'SPEC_COMPOSE',
+      guard: { type: 'not-exists', key: 'needsPart' },
+    },
+    { id: 'e-part-to-spec', from: 'DEFINE_PART', to: 'SPEC_COMPOSE', event: 'NEXT' },
+    { id: 'e-spec-done', from: 'SPEC_COMPOSE', to: 'DONE', event: 'NEXT' },
+  ],
+};
+
+// ---------------------------------------------------------------------------
+// Registry helper
+// ---------------------------------------------------------------------------
+
+/** Register both workflows in the correct order (sub-workflow first). */
+export function registerPhysObjWorkflows(registry: WorkflowRegistry): void {
+  registry.register(definePartObjectWorkflow);
+  registry.register(definePhysicalObjectWorkflow);
+}


### PR DESCRIPTION
## Summary

Translates the recovered Relica PhysObjMachine into Reflex format as a two-workflow set exercising every engine feature: stepping, guards, invocation, stack push/pop, returnMaps, and scoped blackboard reads.

Closes #19

## Key Changes

- **`src/examples/phys-obj-workflows.ts`** — Root workflow `define-physical-object` (6 nodes) with guard-driven fan-out and invocation node, plus sub-workflow `define-part-object` (3 nodes) with returnMap. Registry helper for correct registration order.
- **`src/examples/phys-obj-workflows.test.ts`** — 10 integration tests covering both guard paths (with/without part), stack operations (push/pop depth), scoped blackboard (child reads parent, local isolation), and event traces.

## Implementation Notes

- Root workflow: CLASSIFY → BASIC_DATA → BRANCH → [DEFINE_PART invocation | SPEC_COMPOSE] → DONE
- Fan-out at BRANCH uses `exists`/`not-exists` guards on `needsPart` key
- DEFINE_PART invokes `define-part-object`, returnMap promotes `partConcept` → `Part Concept`
- No-part test variant created via spread override of BASIC_DATA spec (removes `needsPart` write)
- All specs work with existing RuleAgent from M5-1

## Testing

- `npx tsc --noEmit` — zero errors
- `npx vitest run` — 214/214 tests pass (204 existing + 10 new)

## Checklist
- [x] Works with RuleAgent from M5-1
- [x] Exercises guards, invocation, stack ops, returnMaps, scoped blackboard
- [x] No regressions