### PR TITLE
chore: Set up build pipeline for @corpus-relica/reflex (#22)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,11 +1,30 @@
 {
-  "name": "reflex",
-  "version": "0.0.0",
-  "private": true,
+  "name": "@corpus-relica/reflex",
+  "version": "0.1.0",
+  "description": "DAG-based workflow orchestration with call stack composition and append-only blackboard semantics",
+  "license": "MIT",
   "type": "module",
+  "exports": {
+    ".": {
+      "import": "./dist/esm/index.js",
+      "require": "./dist/cjs/index.js",
+      "types": "./dist/types/index.d.ts"
+    }
+  },
+  "main": "./dist/cjs/index.js",
+  "module": "./dist/esm/index.js",
+  "types": "./dist/types/index.d.ts",
+  "files": [
+    "dist"
+  ],
   "scripts": {
+    "build": "yarn build:esm && yarn build:cjs",
+    "build:esm": "tsc --project tsconfig.build.esm.json",
+    "build:cjs": "tsc --project tsconfig.build.cjs.json && echo '{\"type\":\"commonjs\"}' > dist/cjs/package.json",
+    "clean": "rm -rf dist",
     "test": "vitest run",
-    "test:watch": "vitest"
+    "test:watch": "vitest",
+    "prepublishOnly": "yarn clean && yarn build"
   },
   "devDependencies": {
     "typescript": "^5.7.0",

--- a/src/blackboard.ts
+++ b/src/blackboard.ts
@@ -6,7 +6,7 @@ import {
   BlackboardReader,
   BlackboardSource,
   BlackboardWrite,
-} from './types';
+} from './types.js';
 
 // ---------------------------------------------------------------------------
 // Scoped Blackboard Reader

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -22,10 +22,10 @@ import {
   EngineEvent,
   EventHandler,
   EngineStatus,
-} from './types';
-import { WorkflowRegistry } from './registry';
-import { ScopedBlackboard, ScopedBlackboardReader } from './blackboard';
-import { filterEdges } from './guards';
+} from './types.js';
+import { WorkflowRegistry } from './registry.js';
+import { ScopedBlackboard, ScopedBlackboardReader } from './blackboard.js';
+import { filterEdges } from './guards.js';
 
 // ---------------------------------------------------------------------------
 // Engine Error

--- a/src/guards.ts
+++ b/src/guards.ts
@@ -1,7 +1,7 @@
 // Reflex — Guard Evaluation
 // Implements DESIGN.md Section 2.8
 
-import { BuiltinGuard, CustomGuard, Guard, Edge, BlackboardReader } from './types';
+import { BuiltinGuard, CustomGuard, Guard, Edge, BlackboardReader } from './types.js';
 
 // ---------------------------------------------------------------------------
 // Guard Result Type

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,8 @@
+// Reflex — Public Entry Point
+// Minimal barrel export for build verification. M6-2 will define the curated API.
+
+export * from './types.js';
+export * from './registry.js';
+export * from './blackboard.js';
+export * from './guards.js';
+export * from './engine.js';

--- a/src/registry.ts
+++ b/src/registry.ts
@@ -1,7 +1,7 @@
 // Reflex — Workflow Registry with DAG Validation
 // Implements DESIGN.md Section 3.3
 
-import { Workflow } from './types';
+import { Workflow } from './types.js';
 
 // ---------------------------------------------------------------------------
 // Validation Error

--- a/tsconfig.build.cjs.json
+++ b/tsconfig.build.cjs.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.build.json",
+  "compilerOptions": {
+    "module": "CommonJS",
+    "moduleResolution": "node",
+    "outDir": "dist/cjs",
+    "declaration": false,
+    "declarationMap": false
+  }
+}

--- a/tsconfig.build.esm.json
+++ b/tsconfig.build.esm.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.build.json",
+  "compilerOptions": {
+    "module": "Node16",
+    "outDir": "dist/esm",
+    "declarationDir": "dist/types"
+  }
+}

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "moduleResolution": "node16",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "declaration": true,
+    "declarationMap": true,
+    "rootDir": "src"
+  },
+  "include": ["src"],
+  "exclude": ["src/**/*.test.ts", "src/examples/**/*"]
+}


### PR DESCRIPTION
## Summary

Sets up the build pipeline for publishing Reflex as `@corpus-relica/reflex`. Dual ESM + CJS output using plain tsc — no new dependencies.

Closes #22

## Key Changes

- **3 build tsconfigs**: shared base (`node16` resolution, test exclusion) + ESM variant + CJS variant
- **Dual output**: `dist/esm/` (ESM), `dist/cjs/` (CommonJS with `{"type":"commonjs"}` marker), `dist/types/` (declarations + maps)
- **Import extensions**: source files use `.js` extensions on relative imports for `node16` compliance. Test files unchanged (vitest uses bundler resolution).
- **`src/index.ts`**: minimal barrel re-export of all modules. M6-2 will define the curated public API.
- **`package.json`**: `@corpus-relica/reflex` v0.1.0 with `exports`, `main`, `module`, `types`, `files`, build scripts

## Implementation Notes

- ESM build uses `module: Node16` + `moduleResolution: node16`
- CJS build uses `module: CommonJS` + `moduleResolution: node` (classic). Node16 module output follows root `"type": "module"` and emits ESM, so the CJS config needs classic resolution to produce CommonJS.
- Dev tsconfig stays unchanged — `bundler` resolution for IDE and vitest

## Testing

- `npx tsc --noEmit`: zero errors
- `npx vitest run`: 231/231 tests pass (no regressions)
- `yarn build`: 25 files in dist/ (no tests, no examples)

## Checklist
- [x] Build produces correct ESM output
- [x] Build produces correct CJS output  
- [x] Type declarations emitted
- [x] No test files in dist/
- [x] All existing tests pass