### PR TITLE
feat: Define curated public API surface (#23)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,66 @@
-// Reflex — Public Entry Point
-// Minimal barrel export for build verification. M6-2 will define the curated API.
+// Reflex — Public API Surface
 
-export * from './types.js';
-export * from './registry.js';
-export * from './blackboard.js';
-export * from './guards.js';
-export * from './engine.js';
+import { WorkflowRegistry } from './registry.js';
+import { ReflexEngine } from './engine.js';
+import type { DecisionAgent } from './types.js';
+
+// ---------------------------------------------------------------------------
+// Factory functions
+// ---------------------------------------------------------------------------
+
+/** Options for engine creation. Reserved for future extension. */
+export interface EngineOptions {}
+
+/** Create a WorkflowRegistry. Register workflows before creating an engine. */
+export function createRegistry(): WorkflowRegistry {
+  return new WorkflowRegistry();
+}
+
+/** Create a ReflexEngine bound to a registry and decision agent. */
+export function createEngine(
+  registry: WorkflowRegistry,
+  agent: DecisionAgent,
+  _options?: EngineOptions,
+): ReflexEngine {
+  return new ReflexEngine(registry, agent);
+}
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type {
+  NodeSpec,
+  ReturnMapping,
+  InvocationSpec,
+  Node,
+  BuiltinGuard,
+  CustomGuard,
+  Guard,
+  Edge,
+  Workflow,
+  BlackboardSource,
+  BlackboardEntry,
+  BlackboardWrite,
+  StackFrame,
+  BlackboardReader,
+  DecisionContext,
+  Decision,
+  DecisionAgent,
+  StepResult,
+  EngineEvent,
+  EngineStatus,
+  RunResult,
+  EventHandler,
+} from './types.js';
+
+// ---------------------------------------------------------------------------
+// Classes and error types
+// ---------------------------------------------------------------------------
+
+export { WorkflowRegistry } from './registry.js';
+export { WorkflowValidationError } from './registry.js';
+export type { ValidationErrorCode } from './registry.js';
+
+export { ReflexEngine } from './engine.js';
+export { EngineError } from './engine.js';


### PR DESCRIPTION
## Summary
Replace wildcard barrel exports with a curated public API surface for `@corpus-relica/reflex`. Adds factory functions as the primary consumer-facing API and suppresses internal implementation details.

## Issue Resolution
Closes #23

## Key Changes
- `createEngine(registry, agent, options?)` factory function
- `createRegistry()` factory function
- `EngineOptions` interface (empty for v-alpha, forward declaration)
- All 22 types from `types.ts` re-exported
- `WorkflowRegistry`, `ReflexEngine`, error classes exported
- Internal symbols suppressed (`ScopedBlackboard`, guard evaluators, etc.)

## Testing
- `npx tsc --noEmit`: zero errors
- `npx vitest run`: 231/231 tests pass
- `yarn build`: produces correct dist/ with only curated exports in type declarations