### PR TITLE
docs: Update README for v-alpha release (#24)

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,78 @@ Reflex provides a formally characterized execution model (Chomsky Type 1, contex
 
 > The name comes from the mirror system in SLR cameras that directs light through the correct path.
 
+## Install
+
+```bash
+npm install @corpus-relica/reflex
+```
+
+## Quick Start
+
+```typescript
+import {
+  createRegistry,
+  createEngine,
+  type Workflow,
+  type DecisionAgent,
+  type DecisionContext,
+  type Decision,
+} from '@corpus-relica/reflex';
+
+// 1. Define a workflow
+const workflow: Workflow = {
+  id: 'greeting',
+  entry: 'ASK',
+  nodes: {
+    ASK:    { id: 'ASK',    spec: { prompt: 'What is your name?' } },
+    GREET:  { id: 'GREET',  spec: { prompt: 'Say hello' } },
+    DONE:   { id: 'DONE',   spec: {} },
+  },
+  edges: [
+    { id: 'e1', from: 'ASK',   to: 'GREET', event: 'NEXT' },
+    { id: 'e2', from: 'GREET', to: 'DONE',  event: 'NEXT' },
+  ],
+};
+
+// 2. Implement a decision agent
+const agent: DecisionAgent = {
+  async resolve(ctx: DecisionContext): Promise<Decision> {
+    const nodeId = ctx.node.id;
+
+    if (nodeId === 'ASK') {
+      return {
+        type: 'advance',
+        edge: 'e1',
+        writes: [{ key: 'name', value: 'World' }],
+      };
+    }
+
+    if (nodeId === 'GREET') {
+      const name = ctx.blackboard.get('name');
+      return {
+        type: 'advance',
+        edge: 'e2',
+        writes: [{ key: 'greeting', value: `Hello, ${name}!` }],
+      };
+    }
+
+    // Terminal node — complete the workflow
+    return { type: 'complete' };
+  },
+};
+
+// 3. Run the engine
+const registry = createRegistry();
+registry.register(workflow);
+
+const engine = createEngine(registry, agent);
+await engine.init('greeting');
+const result = await engine.run();
+
+console.log(result.status);                  // 'completed'
+console.log(engine.blackboard().get('greeting')); // 'Hello, World!'
+```
+
 ## Core Concepts
 
 **DAG Workflows** — Directed acyclic graphs of nodes and edges. No cycles — repetition happens through recursive sub-workflow invocation, keeping loops visible in the call stack rather than hidden in graph structure.
@@ -50,14 +122,42 @@ Reflex provides a formally characterized execution model (Chomsky Type 1, contex
 
 Reflex implements a pushdown automaton with append-only tape — equivalent to a linear-bounded automaton (Type 1, context-sensitive). The append-only constraint is the principled ceiling: maximal expressiveness while preserving the invariant that established context is never contradicted. See [DESIGN.md](DESIGN.md) Section 1 for the formal model and its caveats.
 
+## API Reference
+
+### Factory Functions
+
+```typescript
+createRegistry(): WorkflowRegistry
+```
+
+Create a workflow registry. Register workflows before creating an engine.
+
+```typescript
+createEngine(registry: WorkflowRegistry, agent: DecisionAgent, options?: EngineOptions): ReflexEngine
+```
+
+Create an engine bound to a registry and decision agent.
+
+### Types
+
+**Workflow definition** — `Workflow`, `Node`, `NodeSpec`, `Edge`, `InvocationSpec`, `ReturnMapping`, `Guard`, `BuiltinGuard`, `CustomGuard`
+
+**Decision agent** — `DecisionAgent`, `DecisionContext`, `Decision`, `BlackboardReader`, `BlackboardWrite`, `BlackboardEntry`, `BlackboardSource`
+
+**Engine results** — `StepResult`, `RunResult`, `EngineEvent`, `EngineStatus`, `EventHandler`, `StackFrame`
+
+**Errors** — `WorkflowValidationError`, `ValidationErrorCode`, `EngineError`
+
+See [DESIGN.md](DESIGN.md) for complete type definitions and semantics.
+
 ## Status
 
-**Pre-alpha** — Design phase. The [design document](DESIGN.md) is stable after three refinement passes. The [roadmap](ROADMAP.md) defines 6 milestones toward a v-alpha release. No implementation yet.
+**v-alpha** — Implementation complete. All 6 milestones shipped: types & DAG validation, blackboard, guards, execution engine, integration tests, packaging. 231 tests passing. ESM + CJS dual output.
 
 ## Documentation
 
 - [DESIGN.md](DESIGN.md) — Formal model, core types, runtime architecture, extension points, boundaries
-- [ROADMAP.md](ROADMAP.md) — Phased implementation plan (6 milestones, 21 issues)
+- [ROADMAP.md](ROADMAP.md) — Phased implementation plan (6 milestones, 24 issues)
 
 ## License
 


### PR DESCRIPTION
## Summary
Updates README.md to reflect the completed v-alpha implementation, adding Install, Quick Start, and API Reference sections.

## Issue Resolution
Closes #24

The issue requires: what Reflex is (one paragraph), install + quick start, link to DESIGN.md, and API reference. All four are now present.

## Key Changes
- Added Install section with npm package name
- Added Quick Start with a 3-node greeting workflow example (type-checked)
- Added API Reference with factory function signatures and types grouped by purpose
- Updated Status from "Pre-alpha — Design phase. No implementation yet." to "v-alpha — Implementation complete."
- Updated ROADMAP issue count (21 → 24)
- Kept all existing conceptual content (Core Concepts, Architecture, Formal Properties, etc.)

## Testing
- Quick start code example type-checked against project tsconfig (zero errors)
- All 231 existing tests still pass
- All markdown links verified (DESIGN.md, ROADMAP.md, LICENSE)
- Grepped for stale "pre-alpha" language — none remains