### PR TITLE
✨ feat(go/engine): Add seed blackboard support to Init() — Go port of #79

### DIFF
--- a/go/types.go
+++ b/go/types.go
@@ -133,6 +133,14 @@ type BlackboardEntry struct {
 	Timestamp int64            `json:"timestamp"`
 }
 
+// InitOptions configures optional parameters for Engine.Init().
+type InitOptions struct {
+	// Blackboard entries to seed the root workflow's blackboard before the
+	// first step executes. Analogous to passing arguments to main().
+	// Seed entries are sourced from nodeId "__init__" for traceability.
+	Blackboard []BlackboardWrite
+}
+
 // BlackboardWrite is a key-value pair to append to the blackboard.
 type BlackboardWrite struct {
 	Key   string `json:"key"`


### PR DESCRIPTION
## Summary

Port of #72 / PR #79 (TypeScript) to the Go implementation.

`Init()` now accepts optional `InitOptions` to seed the root workflow's blackboard before the first step executes:

```go
engine.Init("my-workflow", reflex.InitOptions{
    Blackboard: []reflex.BlackboardWrite{
        {Key: "project", Value: "/foo/bar"},
        {Key: "provider", Value: "ollama"},
    },
})
```

### Implementation

- **`InitOptions` type** in `types.go` — matches TypeScript `InitOptions` interface
- **Variadic `Init()` signature** — `Init(workflowID string, opts ...InitOptions)` — fully backward-compatible
- **`__init__` source node** — seed entries use `nodeId: "__init__"` matching the TS implementation
- **`blackboard:write` event** emitted for seed entries, consistent with TS behavior

### Tests (7 new)

| Test | Verifies |
|------|----------|
| seed values available on first step | Agent sees seeded values in first `Resolve()` call |
| seed emits blackboard:write event | Init emits event with correct entries and source |
| seed source has correct workflow ID | Source has `workflowId`, `nodeId=__init__`, `stackDepth=0` |
| no options is backward compatible | `Init(id)` still works, empty blackboard |
| empty options is backward compatible | `Init(id, InitOptions{})` still works, empty blackboard |
| seed values persist through execution | Seed values readable after workflow completes |
| seed values visible in sub-workflow | Scope chain visibility from child workflows |

### Changes

- `go/types.go`: Add `InitOptions` struct
- `go/engine.go`: Update `Init()` signature + seed logic (18 lines added)
- `go/engine_test.go`: 7 new test cases (200 lines)

All 81 existing + new tests pass with `-race`. Zero regressions.

Closes #72 (Go implementation)