### PR TITLE
fix(go): Emit node:enter for entry node during Init() (#73)

### DIFF
--- a/go/engine.go
+++ b/go/engine.go
@@ -81,6 +81,15 @@ func (e *Engine) Init(workflowID string, opts ...InitOptions) (string, error) {
 		})
 	}
 
+	// Emit node:enter for the entry node so every node:exit in the first
+	// step() has a matching node:enter.
+	entryNode := w.Nodes[w.Entry]
+	e.emit(EventNodeEnter, Event{
+		Type:       EventNodeEnter,
+		NodeID:     entryNode.ID,
+		WorkflowID: workflowID,
+	})
+
 	return e.sessionID, nil
 }
 

--- a/go/examples/e2e_test.go
+++ b/go/examples/e2e_test.go
@@ -78,12 +78,12 @@ func TestE2EEventTracking(t *testing.T) {
 	_, _ = e.Init("linear")
 	_, _ = e.Run(context.Background())
 
-	// A→B, B→C = 2 edge traversals, 2 node enters
+	// A (Init), A→B, B→C = 2 edge traversals, 3 node enters
 	if edgeTraversals != 2 {
 		t.Errorf("expected 2 edge traversals, got %d", edgeTraversals)
 	}
-	if nodeEnters != 2 {
-		t.Errorf("expected 2 node enters, got %d", nodeEnters)
+	if nodeEnters != 3 {
+		t.Errorf("expected 3 node enters, got %d", nodeEnters)
 	}
 }
 


### PR DESCRIPTION
## Summary
- `Init()` now emits `node:enter` for the workflow entry node after session setup and seed blackboard writes
- Fixes the invariant that every `node:exit` has a matching `node:enter` — previously the entry node was the only node that never received `node:enter`

Closes #73 (Go companion for #71)

## Key Changes
- `go/engine.go` — 4-line addition in `Init()` to emit `node:enter` for the entry node
- `go/engine_test.go` — Updated `TestEngineEvents` expected sequence (7→8 events), added `TestEngineInitEntryNodeEnter` with 3 sub-tests
- `go/examples/e2e_test.go` — Updated `TestE2EEventTracking` node:enter count (2→3)

## Event ordering after fix
```
Init():    blackboard:write (seed, if any) → node:enter (entry node)
Step() 1:  node:exit (entry) → edge:traverse → node:enter (next)
Step() N:  ...
```

## Test plan
- [ ] `go test ./...` passes (Go not available on dev machine — CI or manual verification needed)
- [ ] No double `node:enter` for entry node on first step
- [ ] Event ordering: seed writes before entry node enter