### PR TITLE
✨ feat(go/blackboard): Add cursor API for incremental reads (#83)

### DIFF
--- a/go/engine.go
+++ b/go/engine.go
@@ -345,6 +345,20 @@ func (e *Engine) Blackboard() BlackboardReader {
 	return e.buildBlackboardReader()
 }
 
+// CurrentBlackboard returns a read-only cursor interface for the active
+// workflow's blackboard. During sub-workflow execution, this returns the
+// child workflow's blackboard (not the parent's).
+//
+// Use this for cursor-based incremental reads (e.g., streaming
+// persistence). For scoped reads across the full call stack, use
+// Blackboard() instead. Returns nil if no session is active.
+func (e *Engine) CurrentBlackboard() CursorReader {
+	if e.currentBlackboard == nil {
+		return nil
+	}
+	return e.currentBlackboard
+}
+
 // Stack returns a snapshot of the call stack.
 func (e *Engine) Stack() []StackFrame {
 	return e.stackSnapshot()

--- a/go/examples/streaming_persistence_test.go
+++ b/go/examples/streaming_persistence_test.go
@@ -1,0 +1,144 @@
+package examples
+
+import (
+	"context"
+	"testing"
+
+	reflex "github.com/corpus-relica/reflex/go"
+)
+
+// agentFn wraps a function as a DecisionAgent for inline test agents.
+type agentFn func(ctx context.Context, dc reflex.DecisionContext) (reflex.Decision, error)
+
+func (f agentFn) Resolve(ctx context.Context, dc reflex.DecisionContext) (reflex.Decision, error) {
+	return f(ctx, dc)
+}
+
+// TestStreamingPersistence demonstrates cursor-based incremental reads
+// for streaming persistence — reading only new blackboard entries after
+// each step instead of re-scanning the full log.
+//
+// This pattern is used in production by khaos-wfl to persist workflow
+// state to NDJSON files without quadratic duplication.
+func TestStreamingPersistence(t *testing.T) {
+	r := reflex.NewRegistry()
+	_ = r.Register(&reflex.Workflow{
+		ID:    "pipeline",
+		Entry: "PARSE",
+		Nodes: map[string]*reflex.Node{
+			"PARSE":   {ID: "PARSE", Spec: reflex.NodeSpec{"writes": []reflex.BlackboardWrite{{Key: "parsed", Value: true}}}},
+			"ANALYZE": {ID: "ANALYZE", Spec: reflex.NodeSpec{"writes": []reflex.BlackboardWrite{{Key: "score", Value: 85}}}},
+			"DONE":    {ID: "DONE", Spec: reflex.NodeSpec{"complete": true}},
+		},
+		Edges: []reflex.Edge{
+			{ID: "e1", From: "PARSE", To: "ANALYZE", Event: "NEXT"},
+			{ID: "e2", From: "ANALYZE", To: "DONE", Event: "NEXT"},
+		},
+	})
+
+	e := reflex.NewEngine(r, NewRuleAgent())
+	_, _ = e.Init("pipeline")
+
+	// Snapshot cursor before stepping
+	bb := e.CurrentBlackboard()
+	if bb == nil {
+		t.Fatal("expected non-nil CurrentBlackboard after Init")
+	}
+	cursor := bb.Cursor()
+
+	// Simulate a persistence log
+	var persistedEntries []reflex.BlackboardEntry
+
+	for {
+		result, err := e.Step(context.Background())
+		if err != nil {
+			t.Fatalf("step error: %v", err)
+		}
+
+		// Read ONLY new entries since last cursor position
+		entries, next := e.CurrentBlackboard().EntriesFrom(cursor)
+		persistedEntries = append(persistedEntries, entries...)
+		cursor = next
+
+		if result.Status == reflex.StepCompleted {
+			break
+		}
+	}
+
+	// Verify: we captured entries without duplicates
+	if len(persistedEntries) < 2 {
+		t.Errorf("expected ≥2 persisted entries (parsed + score), got %d", len(persistedEntries))
+	}
+
+	// Verify specific keys were captured
+	keys := make(map[string]bool)
+	for _, e := range persistedEntries {
+		keys[e.Key] = true
+	}
+	if !keys["parsed"] {
+		t.Error("missing 'parsed' key in persisted entries")
+	}
+	if !keys["score"] {
+		t.Error("missing 'score' key in persisted entries")
+	}
+}
+
+// TestSeedBlackboard demonstrates initializing a workflow with seed values.
+// Seed values configure the workflow at Init() time — the agent can read
+// them to make decisions without hardcoding per-workflow behavior.
+func TestSeedBlackboard(t *testing.T) {
+	r := reflex.NewRegistry()
+	_ = r.Register(&reflex.Workflow{
+		ID:    "configurable",
+		Entry: "RUN",
+		Nodes: map[string]*reflex.Node{
+			"RUN":  {ID: "RUN", Spec: reflex.NodeSpec{}},
+			"DONE": {ID: "DONE", Spec: reflex.NodeSpec{"complete": true}},
+		},
+		Edges: []reflex.Edge{
+			{ID: "e1", From: "RUN", To: "DONE", Event: "NEXT"},
+		},
+	})
+
+	// Init with seed values — configures the workflow run
+	e := reflex.NewEngine(r, NewRuleAgent())
+	_, err := e.Init("configurable", reflex.InitOptions{
+		Blackboard: []reflex.BlackboardWrite{
+			{Key: "project_path", Value: "/Users/demo/projects/test.kspd"},
+			{Key: "max_retries", Value: 3},
+			{Key: "verbose", Value: true},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Read seeds back from blackboard
+	bb := e.Blackboard()
+
+	path, ok := bb.Get("project_path")
+	if !ok || path != "/Users/demo/projects/test.kspd" {
+		t.Errorf("project_path = %v, ok=%v", path, ok)
+	}
+
+	retries, ok := bb.Get("max_retries")
+	if !ok || retries != 3 {
+		t.Errorf("max_retries = %v, ok=%v", retries, ok)
+	}
+
+	verbose, ok := bb.Get("verbose")
+	if !ok || verbose != true {
+		t.Errorf("verbose = %v, ok=%v", verbose, ok)
+	}
+
+	// Seeds are also visible via cursor
+	cur := e.CurrentBlackboard()
+	entries, _ := cur.EntriesFrom(0)
+	if len(entries) < 3 {
+		t.Errorf("expected ≥3 seed entries, got %d", len(entries))
+	}
+}
+
+// NOTE: TestSuspendWithWritesPersistence lives in the dogfood-combined
+// branch only — it depends on the "Apply Decision.Writes on suspend"
+// fix which is not yet upstreamed.


### PR DESCRIPTION
## Summary

Add `Cursor` type and `EntriesFrom()` to `ScopedBlackboard` for efficient streaming persistence. Consumers track a cursor position and read only new entries after each `Step()` call — no duplicates, no re-scanning.

Closes #83

## New API

```go
type Cursor int

func (bb *ScopedBlackboard) Cursor() Cursor
func (bb *ScopedBlackboard) EntriesFrom(c Cursor) ([]BlackboardEntry, Cursor)
func (e *Engine) RootBlackboard() *ScopedBlackboard
```

### Usage

```go
cur := engine.RootBlackboard().Cursor()
for {
    result, _ := engine.Step(ctx)
    entries, next := engine.RootBlackboard().EntriesFrom(cur)
    appendNDJSON(entries) // only new entries
    cur = next
    if result.Status == reflex.StepCompleted { break }
}
```

## Key Design Decisions

- **`Cursor` is a named `int`** — simple for v-alpha, can become opaque later without breaking callers
- **`EntriesFrom` returns `(entries, next)` tuple** — eliminates off-by-one bugs
- **`RootBlackboard()` returns `*ScopedBlackboard`** — cursor is a write-side concern; read-side `BlackboardReader` interface unchanged
- **Negative cursor → returns all entries; past-end → returns nil + current end**
- **Thread-safe** — uses existing `sync.RWMutex` pattern
- **Zero new dependencies**

## Test Plan

13 new test cases:
1. Cursor starts at zero on empty blackboard
2. Cursor advances with appends
3. `EntriesFrom(0)` returns all entries
4. `EntriesFrom(cursor)` returns only delta
5. `EntriesFrom` past end returns nil + current end
6. `EntriesFrom` negative returns all entries
7. Concurrent writer + cursor reader (race-safe)
8. Seeded blackboard has correct initial cursor
9. Multiple incremental reads produce no duplicates
10. `RootBlackboard()` before `Init()` returns nil
11. `RootBlackboard()` after `Init()` returns non-nil
12. Cursor tracks engine seed writes
13. `RootBlackboard()` during sub-workflow returns child's blackboard

All tests pass including `go test -race`.