### PR TITLE
M7-1: Workflow JSON Schema (#55)

### DIFF
--- a/docs/fixtures/define-part-object.json
+++ b/docs/fixtures/define-part-object.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "../workflow-schema.json",
+  "id": "define-part-object",
+  "entry": "PART_CLASSIFY",
+  "nodes": {
+    "PART_CLASSIFY": {
+      "id": "PART_CLASSIFY",
+      "spec": {
+        "writes": [{ "key": "partContext", "value": "Physical Object — Part" }]
+      }
+    },
+    "PART_BASIC_DATA": {
+      "id": "PART_BASIC_DATA",
+      "spec": {
+        "writes": [{ "key": "partConcept", "value": "Aluminum Housing" }]
+      }
+    },
+    "PART_DONE": {
+      "id": "PART_DONE",
+      "spec": {
+        "complete": true,
+        "writes": [{ "key": "partStatus", "value": "complete" }]
+      }
+    }
+  },
+  "edges": [
+    { "id": "e-part-classify-basic", "from": "PART_CLASSIFY", "to": "PART_BASIC_DATA", "event": "NEXT" },
+    { "id": "e-part-basic-done", "from": "PART_BASIC_DATA", "to": "PART_DONE", "event": "NEXT" }
+  ]
+}

--- a/docs/fixtures/define-physical-object.json
+++ b/docs/fixtures/define-physical-object.json
@@ -1,0 +1,75 @@
+{
+  "$schema": "../workflow-schema.json",
+  "id": "define-physical-object",
+  "entry": "CLASSIFY",
+  "nodes": {
+    "CLASSIFY": {
+      "id": "CLASSIFY",
+      "spec": {
+        "writes": [{ "key": "workflowType", "value": "define-physical-object" }],
+        "edge": "e-classify-basic"
+      }
+    },
+    "BASIC_DATA": {
+      "id": "BASIC_DATA",
+      "spec": {
+        "writes": [
+          { "key": "conceptName", "value": "Steel Pipe" },
+          { "key": "needsPart", "value": true }
+        ],
+        "edge": "e-basic-branch"
+      }
+    },
+    "BRANCH": {
+      "id": "BRANCH",
+      "spec": {
+        "edge": ["e-branch-to-part", "e-branch-to-spec"]
+      }
+    },
+    "DEFINE_PART": {
+      "id": "DEFINE_PART",
+      "spec": {},
+      "invokes": {
+        "workflowId": "define-part-object",
+        "returnMap": [
+          { "parentKey": "Part Concept", "childKey": "partConcept" }
+        ]
+      }
+    },
+    "SPEC_COMPOSE": {
+      "id": "SPEC_COMPOSE",
+      "spec": {
+        "writes": [
+          { "key": "specRelation", "value": "Steel Pipe specializes Physical Object" }
+        ]
+      }
+    },
+    "DONE": {
+      "id": "DONE",
+      "spec": {
+        "complete": true,
+        "writes": [{ "key": "status", "value": "physical-object-defined" }]
+      }
+    }
+  },
+  "edges": [
+    { "id": "e-classify-basic", "from": "CLASSIFY", "to": "BASIC_DATA", "event": "NEXT" },
+    { "id": "e-basic-branch", "from": "BASIC_DATA", "to": "BRANCH", "event": "NEXT" },
+    {
+      "id": "e-branch-to-part",
+      "from": "BRANCH",
+      "to": "DEFINE_PART",
+      "event": "DEFINE_PART",
+      "guard": { "type": "exists", "key": "needsPart" }
+    },
+    {
+      "id": "e-branch-to-spec",
+      "from": "BRANCH",
+      "to": "SPEC_COMPOSE",
+      "event": "SPEC_COMPOSE",
+      "guard": { "type": "not-exists", "key": "needsPart" }
+    },
+    { "id": "e-part-to-spec", "from": "DEFINE_PART", "to": "SPEC_COMPOSE", "event": "NEXT" },
+    { "id": "e-spec-done", "from": "SPEC_COMPOSE", "to": "DONE", "event": "NEXT" }
+  ]
+}

--- a/docs/fixtures/greeting.json
+++ b/docs/fixtures/greeting.json
@@ -1,0 +1,34 @@
+{
+  "$schema": "../workflow-schema.json",
+  "id": "greeting",
+  "entry": "ASK_NAME",
+  "nodes": {
+    "ASK_NAME": {
+      "id": "ASK_NAME",
+      "spec": {
+        "prompt": "Ask the user for their name",
+        "outputKey": "userName"
+      }
+    },
+    "GREET": {
+      "id": "GREET",
+      "description": "Generate a personalized greeting",
+      "spec": {
+        "prompt": "Greet the user by name",
+        "inputKey": "userName",
+        "outputKey": "greeting"
+      }
+    },
+    "FAREWELL": {
+      "id": "FAREWELL",
+      "spec": {
+        "prompt": "Say goodbye",
+        "outputKey": "farewell"
+      }
+    }
+  },
+  "edges": [
+    { "id": "e-ask-greet", "from": "ASK_NAME", "to": "GREET", "event": "NEXT" },
+    { "id": "e-greet-farewell", "from": "GREET", "to": "FAREWELL", "event": "NEXT" }
+  ]
+}

--- a/docs/workflow-schema.json
+++ b/docs/workflow-schema.json
@@ -1,0 +1,209 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://github.com/corpus-relica/reflex/docs/workflow-schema.json",
+  "title": "Reflex Workflow",
+  "description": "JSON Schema for a Reflex DAG workflow definition. See DESIGN.md for the formal specification.",
+  "type": "object",
+  "properties": {
+    "$schema": {
+      "type": "string",
+      "description": "Optional JSON Schema reference for editor support."
+    },
+    "id": {
+      "type": "string",
+      "description": "Unique identifier for this workflow."
+    },
+    "entry": {
+      "type": "string",
+      "description": "ID of the entry node — must be a key in the nodes object."
+    },
+    "nodes": {
+      "type": "object",
+      "description": "Dictionary of node ID → node definition.",
+      "additionalProperties": { "$ref": "#/definitions/Node" }
+    },
+    "edges": {
+      "type": "array",
+      "description": "Directed edges connecting nodes in the DAG.",
+      "items": { "$ref": "#/definitions/Edge" }
+    },
+    "metadata": {
+      "type": "object",
+      "description": "Optional freeform metadata for the workflow.",
+      "additionalProperties": true
+    }
+  },
+  "required": ["id", "entry", "nodes", "edges"],
+  "additionalProperties": false,
+
+  "definitions": {
+    "Node": {
+      "type": "object",
+      "description": "A single step in the workflow DAG.",
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "Unique node identifier (must match the key in the nodes object)."
+        },
+        "description": {
+          "type": "string",
+          "description": "Optional human-readable description of this node."
+        },
+        "spec": {
+          "$ref": "#/definitions/NodeSpec"
+        },
+        "invokes": {
+          "$ref": "#/definitions/InvocationSpec"
+        }
+      },
+      "required": ["id", "spec"],
+      "additionalProperties": false
+    },
+
+    "NodeSpec": {
+      "type": "object",
+      "description": "Domain-specific data — opaque to Reflex. The decision agent interprets it, not the engine.",
+      "additionalProperties": true
+    },
+
+    "InvocationSpec": {
+      "type": "object",
+      "description": "Declares that a node is a composition point. Entering this node automatically starts the sub-workflow.",
+      "properties": {
+        "workflowId": {
+          "type": "string",
+          "description": "ID of the sub-workflow to invoke."
+        },
+        "returnMap": {
+          "type": "array",
+          "description": "How to propagate results from the child's local blackboard back to the parent.",
+          "items": { "$ref": "#/definitions/ReturnMapping" }
+        }
+      },
+      "required": ["workflowId", "returnMap"],
+      "additionalProperties": false
+    },
+
+    "ReturnMapping": {
+      "type": "object",
+      "description": "Maps a child blackboard key to a parent blackboard key on sub-workflow completion.",
+      "properties": {
+        "parentKey": {
+          "type": "string",
+          "description": "Key to write in the parent's local blackboard."
+        },
+        "childKey": {
+          "type": "string",
+          "description": "Key to read from the child's local blackboard."
+        }
+      },
+      "required": ["parentKey", "childKey"],
+      "additionalProperties": false
+    },
+
+    "Edge": {
+      "type": "object",
+      "description": "A directed edge connecting two nodes in the workflow DAG.",
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "Unique edge identifier."
+        },
+        "from": {
+          "type": "string",
+          "description": "Source node ID."
+        },
+        "to": {
+          "type": "string",
+          "description": "Target node ID."
+        },
+        "event": {
+          "type": "string",
+          "description": "Named transition (e.g., 'NEXT', 'DEFINE_PART')."
+        },
+        "guard": {
+          "$ref": "#/definitions/Guard"
+        }
+      },
+      "required": ["id", "from", "to", "event"],
+      "additionalProperties": false
+    },
+
+    "Guard": {
+      "description": "Edge guard — a condition evaluated against the scoped blackboard. Discriminated on the 'type' field.",
+      "oneOf": [
+        {
+          "type": "object",
+          "description": "Passes if the key exists on the blackboard.",
+          "properties": {
+            "type": { "const": "exists" },
+            "key": { "type": "string" }
+          },
+          "required": ["type", "key"],
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "description": "Passes if the key does NOT exist on the blackboard.",
+          "properties": {
+            "type": { "const": "not-exists" },
+            "key": { "type": "string" }
+          },
+          "required": ["type", "key"],
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "description": "Passes if the key exists and its value equals the specified value.",
+          "properties": {
+            "type": { "const": "equals" },
+            "key": { "type": "string" },
+            "value": {
+              "description": "The value to compare against.",
+              "anyOf": [
+                { "type": "string" },
+                { "type": "number" },
+                { "type": "boolean" },
+                { "type": "null" }
+              ]
+            }
+          },
+          "required": ["type", "key", "value"],
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "description": "Passes if the key does not exist or its value does NOT equal the specified value.",
+          "properties": {
+            "type": { "const": "not-equals" },
+            "key": { "type": "string" },
+            "value": {
+              "description": "The value to compare against.",
+              "anyOf": [
+                { "type": "string" },
+                { "type": "number" },
+                { "type": "boolean" },
+                { "type": "null" }
+              ]
+            }
+          },
+          "required": ["type", "key", "value"],
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "description": "A named reference to a custom guard function. Resolved at load time against a guard registry.",
+          "properties": {
+            "type": { "const": "custom" },
+            "name": {
+              "type": "string",
+              "description": "Name of the custom guard function to resolve at load time."
+            }
+          },
+          "required": ["type", "name"],
+          "additionalProperties": false
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Define JSON Schema (draft-07) for the Workflow type, covering all fields from `types.ts` and `types.go`
- Add 3 validation fixture files representing existing test workflows
- All fixtures validated with ajv-cli

## Issue Resolution
Closes #55

## Key Changes
- **`docs/workflow-schema.json`** — Draft-07 schema with definitions for all sub-types: Workflow, Node, NodeSpec, Edge, Guard (5-variant oneOf), InvocationSpec, ReturnMapping
- **`docs/fixtures/greeting.json`** — Simple 3-node workflow (no guards, no invocations)
- **`docs/fixtures/define-part-object.json`** — Linear 3-node sub-workflow with RuleSpec NodeSpec
- **`docs/fixtures/define-physical-object.json`** — Full-complexity workflow: fan-out, exists/not-exists guards, invocation node with returnMap

## Implementation Notes
- Guard discriminated union uses `oneOf` with `additionalProperties: false` per variant to prevent false positive validation
- Guard `value` restricted to primitives (`string|number|boolean|null`) — can relax later if needed
- Custom guards use `{ "type": "custom", "name": "guardName" }` — resolved at load time (M7-2)
- NodeSpec is fully freeform (`additionalProperties: true`) — opaque to Reflex
- Field names aligned to both TS camelCase and Go JSON struct tags

## Test Plan
- [x] All 3 fixtures pass ajv-cli validation against the schema
- [x] Cross-checked all field names against `typescript/src/types.ts` and `go/types.go`