### PR TITLE
feat: Add loadWorkflow() for JSON workflow definitions (#56)

### DIFF
--- a/go/loader.go
+++ b/go/loader.go
@@ -1,0 +1,188 @@
+package reflex
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+// GuardRegistry maps guard names (from JSON) to Guard implementations.
+type GuardRegistry map[string]Guard
+
+// LoadWorkflowOptions configures optional parameters for LoadWorkflow.
+type LoadWorkflowOptions struct {
+	Guards GuardRegistry
+}
+
+// ---------------------------------------------------------------------------
+// Intermediate JSON types (for edges with guards)
+// ---------------------------------------------------------------------------
+
+type jsonWorkflow struct {
+	Schema   string             `json:"$schema"`
+	ID       string             `json:"id"`
+	Entry    string             `json:"entry"`
+	Nodes    map[string]*Node   `json:"nodes"`
+	Edges    []jsonEdge         `json:"edges"`
+	Metadata map[string]any     `json:"metadata"`
+}
+
+type jsonEdge struct {
+	ID    string           `json:"id"`
+	From  string           `json:"from"`
+	To    string           `json:"to"`
+	Event string           `json:"event"`
+	Guard json.RawMessage  `json:"guard,omitempty"`
+}
+
+// ---------------------------------------------------------------------------
+// LoadWorkflow
+// ---------------------------------------------------------------------------
+
+// LoadWorkflow parses and validates a JSON workflow definition, returning a
+// typed Workflow with guards resolved. Custom guard names are resolved against
+// the GuardRegistry in opts.
+func LoadWorkflow(data []byte, opts *LoadWorkflowOptions) (*Workflow, error) {
+	var jw jsonWorkflow
+	if err := json.Unmarshal(data, &jw); err != nil {
+		return nil, newValidationError(ErrSchemaViolation, "<unknown>",
+			fmt.Sprintf("invalid JSON: %v", err))
+	}
+
+	// Validate required top-level fields
+	if jw.ID == "" {
+		return nil, newValidationError(ErrSchemaViolation, "<unknown>",
+			"missing required field: id")
+	}
+	if jw.Entry == "" {
+		return nil, newValidationError(ErrSchemaViolation, jw.ID,
+			"missing required field: entry")
+	}
+	if jw.Nodes == nil {
+		return nil, newValidationError(ErrSchemaViolation, jw.ID,
+			"missing required field: nodes")
+	}
+	if jw.Edges == nil {
+		return nil, newValidationError(ErrSchemaViolation, jw.ID,
+			"missing required field: edges")
+	}
+
+	// Validate nodes
+	for key, node := range jw.Nodes {
+		if node.ID == "" {
+			return nil, newValidationError(ErrSchemaViolation, jw.ID,
+				fmt.Sprintf("node '%s': missing required field: id", key))
+		}
+		if node.Spec == nil {
+			return nil, newValidationError(ErrSchemaViolation, jw.ID,
+				fmt.Sprintf("node '%s': missing required field: spec", key))
+		}
+	}
+
+	// Process edges and resolve guards
+	edges := make([]Edge, len(jw.Edges))
+	for i, je := range jw.Edges {
+		if je.ID == "" {
+			return nil, newValidationError(ErrSchemaViolation, jw.ID,
+				fmt.Sprintf("edge at index %d: missing required field: id", i))
+		}
+		if je.From == "" {
+			return nil, newValidationError(ErrSchemaViolation, jw.ID,
+				fmt.Sprintf("edge '%s': missing required field: from", je.ID))
+		}
+		if je.To == "" {
+			return nil, newValidationError(ErrSchemaViolation, jw.ID,
+				fmt.Sprintf("edge '%s': missing required field: to", je.ID))
+		}
+		if je.Event == "" {
+			return nil, newValidationError(ErrSchemaViolation, jw.ID,
+				fmt.Sprintf("edge '%s': missing required field: event", je.ID))
+		}
+
+		edge := Edge{
+			ID:    je.ID,
+			From:  je.From,
+			To:    je.To,
+			Event: je.Event,
+		}
+
+		if len(je.Guard) > 0 {
+			guard, err := resolveGuardJSON(je.Guard, jw.ID, je.ID, opts)
+			if err != nil {
+				return nil, err
+			}
+			edge.Guard = guard
+		}
+
+		edges[i] = edge
+	}
+
+	return &Workflow{
+		ID:       jw.ID,
+		Entry:    jw.Entry,
+		Nodes:    jw.Nodes,
+		Edges:    edges,
+		Metadata: jw.Metadata,
+	}, nil
+}
+
+// ---------------------------------------------------------------------------
+// Guard resolution
+// ---------------------------------------------------------------------------
+
+func resolveGuardJSON(raw json.RawMessage, wfID, edgeID string, opts *LoadWorkflowOptions) (Guard, error) {
+	var gm map[string]any
+	if err := json.Unmarshal(raw, &gm); err != nil {
+		return nil, newValidationError(ErrSchemaViolation, wfID,
+			fmt.Sprintf("edge '%s': invalid guard JSON: %v", edgeID, err))
+	}
+
+	typ, ok := gm["type"].(string)
+	if !ok {
+		return nil, newValidationError(ErrSchemaViolation, wfID,
+			fmt.Sprintf("edge '%s': guard missing or invalid 'type' field", edgeID))
+	}
+
+	switch typ {
+	case "exists", "not-exists":
+		key, ok := gm["key"].(string)
+		if !ok {
+			return nil, newValidationError(ErrSchemaViolation, wfID,
+				fmt.Sprintf("edge '%s': guard type '%s' requires 'key' field", edgeID, typ))
+		}
+		return &BuiltinGuard{Type: GuardType(typ), Key: key}, nil
+
+	case "equals", "not-equals":
+		key, ok := gm["key"].(string)
+		if !ok {
+			return nil, newValidationError(ErrSchemaViolation, wfID,
+				fmt.Sprintf("edge '%s': guard type '%s' requires 'key' field", edgeID, typ))
+		}
+		// value is required but may be null
+		value, hasValue := gm["value"]
+		if !hasValue {
+			return nil, newValidationError(ErrSchemaViolation, wfID,
+				fmt.Sprintf("edge '%s': guard type '%s' requires 'value' field", edgeID, typ))
+		}
+		return &BuiltinGuard{Type: GuardType(typ), Key: key, Value: value}, nil
+
+	case "custom":
+		name, ok := gm["name"].(string)
+		if !ok {
+			return nil, newValidationError(ErrSchemaViolation, wfID,
+				fmt.Sprintf("edge '%s': custom guard requires 'name' field", edgeID))
+		}
+		if opts == nil || opts.Guards == nil || opts.Guards[name] == nil {
+			return nil, newValidationError(ErrUnknownGuardReference, wfID,
+				fmt.Sprintf("edge '%s': custom guard '%s' not found in guard registry", edgeID, name))
+		}
+		return opts.Guards[name], nil
+
+	default:
+		return nil, newValidationError(ErrSchemaViolation, wfID,
+			fmt.Sprintf("edge '%s': unknown guard type '%s'", edgeID, typ))
+	}
+}

--- a/go/loader_test.go
+++ b/go/loader_test.go
@@ -1,0 +1,300 @@
+package reflex
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+func fixtureDir() string {
+	_, file, _, _ := runtime.Caller(0)
+	return filepath.Join(filepath.Dir(file), "..", "docs", "fixtures")
+}
+
+func readFixture(t *testing.T, name string) []byte {
+	t.Helper()
+	data, err := os.ReadFile(filepath.Join(fixtureDir(), name))
+	if err != nil {
+		t.Fatalf("read fixture %s: %v", name, err)
+	}
+	return data
+}
+
+func stubGuardFn(_ BlackboardReader) (bool, error) {
+	return true, nil
+}
+
+// assertValidationError is defined in registry_test.go — reused here
+
+// ---------------------------------------------------------------------------
+// Valid inputs — fixtures
+// ---------------------------------------------------------------------------
+
+func TestLoadWorkflow_Greeting(t *testing.T) {
+	wf, err := LoadWorkflow(readFixture(t, "greeting.json"), nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if wf.ID != "greeting" {
+		t.Errorf("id = %q, want greeting", wf.ID)
+	}
+	if wf.Entry != "ASK_NAME" {
+		t.Errorf("entry = %q, want ASK_NAME", wf.Entry)
+	}
+	if len(wf.Nodes) != 3 {
+		t.Errorf("nodes = %d, want 3", len(wf.Nodes))
+	}
+	if len(wf.Edges) != 2 {
+		t.Errorf("edges = %d, want 2", len(wf.Edges))
+	}
+	// No guards on any edge
+	for _, e := range wf.Edges {
+		if e.Guard != nil {
+			t.Errorf("edge %s: expected no guard", e.ID)
+		}
+	}
+}
+
+func TestLoadWorkflow_DefinePhysicalObject(t *testing.T) {
+	wf, err := LoadWorkflow(readFixture(t, "define-physical-object.json"), nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if wf.ID != "define-physical-object" {
+		t.Errorf("id = %q", wf.ID)
+	}
+	if len(wf.Nodes) != 6 {
+		t.Errorf("nodes = %d, want 6", len(wf.Nodes))
+	}
+	if len(wf.Edges) != 6 {
+		t.Errorf("edges = %d, want 6", len(wf.Edges))
+	}
+
+	// Check exists guard on e-branch-to-part
+	var branchToPart *Edge
+	for i := range wf.Edges {
+		if wf.Edges[i].ID == "e-branch-to-part" {
+			branchToPart = &wf.Edges[i]
+			break
+		}
+	}
+	if branchToPart == nil {
+		t.Fatal("edge e-branch-to-part not found")
+	}
+	bg, ok := branchToPart.Guard.(*BuiltinGuard)
+	if !ok {
+		t.Fatalf("guard is %T, want *BuiltinGuard", branchToPart.Guard)
+	}
+	if bg.Type != GuardExists || bg.Key != "needsPart" {
+		t.Errorf("guard = {%s, %s}, want {exists, needsPart}", bg.Type, bg.Key)
+	}
+
+	// Check not-exists guard on e-branch-to-spec
+	var branchToSpec *Edge
+	for i := range wf.Edges {
+		if wf.Edges[i].ID == "e-branch-to-spec" {
+			branchToSpec = &wf.Edges[i]
+			break
+		}
+	}
+	if branchToSpec == nil {
+		t.Fatal("edge e-branch-to-spec not found")
+	}
+	bg2, ok := branchToSpec.Guard.(*BuiltinGuard)
+	if !ok {
+		t.Fatalf("guard is %T, want *BuiltinGuard", branchToSpec.Guard)
+	}
+	if bg2.Type != GuardNotExists || bg2.Key != "needsPart" {
+		t.Errorf("guard = {%s, %s}, want {not-exists, needsPart}", bg2.Type, bg2.Key)
+	}
+}
+
+func TestLoadWorkflow_DefinePartObject(t *testing.T) {
+	wf, err := LoadWorkflow(readFixture(t, "define-part-object.json"), nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if wf.ID != "define-part-object" {
+		t.Errorf("id = %q", wf.ID)
+	}
+	if len(wf.Nodes) != 3 {
+		t.Errorf("nodes = %d, want 3", len(wf.Nodes))
+	}
+	if len(wf.Edges) != 2 {
+		t.Errorf("edges = %d, want 2", len(wf.Edges))
+	}
+}
+
+func TestLoadWorkflow_InvocationSpec(t *testing.T) {
+	wf, err := LoadWorkflow(readFixture(t, "define-physical-object.json"), nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	definePart := wf.Nodes["DEFINE_PART"]
+	if definePart == nil {
+		t.Fatal("node DEFINE_PART not found")
+	}
+	if definePart.Invokes == nil {
+		t.Fatal("DEFINE_PART.Invokes is nil")
+	}
+	if definePart.Invokes.WorkflowID != "define-part-object" {
+		t.Errorf("workflowId = %q", definePart.Invokes.WorkflowID)
+	}
+	if len(definePart.Invokes.ReturnMap) != 1 {
+		t.Fatalf("returnMap len = %d, want 1", len(definePart.Invokes.ReturnMap))
+	}
+	rm := definePart.Invokes.ReturnMap[0]
+	if rm.ParentKey != "Part Concept" || rm.ChildKey != "partConcept" {
+		t.Errorf("returnMap[0] = {%q, %q}", rm.ParentKey, rm.ChildKey)
+	}
+}
+
+func TestLoadWorkflow_NodeSpec(t *testing.T) {
+	wf, err := LoadWorkflow(readFixture(t, "greeting.json"), nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	askName := wf.Nodes["ASK_NAME"]
+	if askName == nil {
+		t.Fatal("node ASK_NAME not found")
+	}
+	if askName.Spec["prompt"] != "Ask the user for their name" {
+		t.Errorf("spec.prompt = %v", askName.Spec["prompt"])
+	}
+	if askName.Spec["outputKey"] != "userName" {
+		t.Errorf("spec.outputKey = %v", askName.Spec["outputKey"])
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Custom guard resolution
+// ---------------------------------------------------------------------------
+
+func TestLoadWorkflow_CustomGuardResolved(t *testing.T) {
+	data := []byte(`{
+		"id": "test",
+		"entry": "A",
+		"nodes": {
+			"A": {"id": "A", "spec": {}},
+			"B": {"id": "B", "spec": {}}
+		},
+		"edges": [{
+			"id": "e1", "from": "A", "to": "B", "event": "NEXT",
+			"guard": {"type": "custom", "name": "myGuard"}
+		}]
+	}`)
+
+	guard := &CustomGuardFunc{Fn: stubGuardFn}
+	wf, err := LoadWorkflow(data, &LoadWorkflowOptions{
+		Guards: GuardRegistry{"myGuard": guard},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if wf.Edges[0].Guard != guard {
+		t.Error("guard not resolved from registry")
+	}
+}
+
+func TestLoadWorkflow_CustomGuardMissing(t *testing.T) {
+	data := []byte(`{
+		"id": "test",
+		"entry": "A",
+		"nodes": {
+			"A": {"id": "A", "spec": {}},
+			"B": {"id": "B", "spec": {}}
+		},
+		"edges": [{
+			"id": "e1", "from": "A", "to": "B", "event": "NEXT",
+			"guard": {"type": "custom", "name": "nonExistent"}
+		}]
+	}`)
+	_, err := LoadWorkflow(data, nil)
+	assertValidationError(t, err, ErrUnknownGuardReference)
+}
+
+func TestLoadWorkflow_CustomGuardMissingFromRegistry(t *testing.T) {
+	data := []byte(`{
+		"id": "test",
+		"entry": "A",
+		"nodes": {
+			"A": {"id": "A", "spec": {}},
+			"B": {"id": "B", "spec": {}}
+		},
+		"edges": [{
+			"id": "e1", "from": "A", "to": "B", "event": "NEXT",
+			"guard": {"type": "custom", "name": "missing"}
+		}]
+	}`)
+	guard := &CustomGuardFunc{Fn: stubGuardFn}
+	_, err := LoadWorkflow(data, &LoadWorkflowOptions{
+		Guards: GuardRegistry{"otherGuard": guard},
+	})
+	assertValidationError(t, err, ErrUnknownGuardReference)
+}
+
+// ---------------------------------------------------------------------------
+// Schema violations
+// ---------------------------------------------------------------------------
+
+func TestLoadWorkflow_InvalidJSON(t *testing.T) {
+	_, err := LoadWorkflow([]byte("not valid json{"), nil)
+	assertValidationError(t, err, ErrSchemaViolation)
+}
+
+func TestLoadWorkflow_MissingID(t *testing.T) {
+	data := []byte(`{"entry":"A","nodes":{"A":{"id":"A","spec":{}}},"edges":[]}`)
+	_, err := LoadWorkflow(data, nil)
+	assertValidationError(t, err, ErrSchemaViolation)
+}
+
+func TestLoadWorkflow_MissingEntry(t *testing.T) {
+	data := []byte(`{"id":"x","nodes":{"A":{"id":"A","spec":{}}},"edges":[]}`)
+	_, err := LoadWorkflow(data, nil)
+	assertValidationError(t, err, ErrSchemaViolation)
+}
+
+func TestLoadWorkflow_MissingNodes(t *testing.T) {
+	data := []byte(`{"id":"x","entry":"A","edges":[]}`)
+	_, err := LoadWorkflow(data, nil)
+	assertValidationError(t, err, ErrSchemaViolation)
+}
+
+func TestLoadWorkflow_MissingEdges(t *testing.T) {
+	data := []byte(`{"id":"x","entry":"A","nodes":{"A":{"id":"A","spec":{}}}}`)
+	_, err := LoadWorkflow(data, nil)
+	assertValidationError(t, err, ErrSchemaViolation)
+}
+
+func TestLoadWorkflow_UnknownGuardType(t *testing.T) {
+	data := []byte(`{
+		"id": "x",
+		"entry": "A",
+		"nodes": {
+			"A": {"id": "A", "spec": {}},
+			"B": {"id": "B", "spec": {}}
+		},
+		"edges": [{
+			"id": "e1", "from": "A", "to": "B", "event": "NEXT",
+			"guard": {"type": "bogus", "key": "x"}
+		}]
+	}`)
+	_, err := LoadWorkflow(data, nil)
+	assertValidationError(t, err, ErrSchemaViolation)
+}
+
+func TestLoadWorkflow_SchemaFieldAllowed(t *testing.T) {
+	// $schema field should be silently ignored
+	wf, err := LoadWorkflow(readFixture(t, "greeting.json"), nil)
+	if err != nil {
+		t.Fatalf("$schema field should be allowed: %v", err)
+	}
+	if wf.ID != "greeting" {
+		t.Errorf("id = %q", wf.ID)
+	}
+}

--- a/go/registry.go
+++ b/go/registry.go
@@ -21,7 +21,9 @@ const (
 	ErrNoTerminalNodes    ValidationErrorCode = "NO_TERMINAL_NODES"
 	ErrDuplicateWorkflowID ValidationErrorCode = "DUPLICATE_WORKFLOW_ID"
 	ErrNodeIDMismatch     ValidationErrorCode = "NODE_ID_MISMATCH"
-	ErrEmptyWorkflow      ValidationErrorCode = "EMPTY_WORKFLOW"
+	ErrEmptyWorkflow          ValidationErrorCode = "EMPTY_WORKFLOW"
+	ErrSchemaViolation        ValidationErrorCode = "SCHEMA_VIOLATION"
+	ErrUnknownGuardReference  ValidationErrorCode = "UNKNOWN_GUARD_REFERENCE"
 )
 
 // ValidationError is returned when a workflow fails structural validation.

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -29,5 +29,8 @@
   "devDependencies": {
     "typescript": "^5.7.0",
     "vitest": "^2.1.0"
+  },
+  "dependencies": {
+    "ajv": "^8.18.0"
   }
 }

--- a/typescript/src/index.ts
+++ b/typescript/src/index.ts
@@ -65,3 +65,10 @@ export type { ValidationErrorCode } from './registry.js';
 
 export { ReflexEngine } from './engine.js';
 export { EngineError } from './engine.js';
+
+// ---------------------------------------------------------------------------
+// Loader (M7-2: Declarative Workflows)
+// ---------------------------------------------------------------------------
+
+export { loadWorkflow } from './loader.js';
+export type { GuardRegistry, LoadWorkflowOptions } from './loader.js';

--- a/typescript/src/loader.test.ts
+++ b/typescript/src/loader.test.ts
@@ -1,0 +1,298 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { loadWorkflow } from './loader';
+import { WorkflowValidationError } from './registry';
+import type { BuiltinGuard, CustomGuard, BlackboardReader } from './types';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const fixtureDir = resolve(__dirname, '../../docs/fixtures');
+
+function readFixture(name: string): string {
+  return readFileSync(resolve(fixtureDir, name), 'utf-8');
+}
+
+function parseFixture(name: string): unknown {
+  return JSON.parse(readFixture(name));
+}
+
+const stubGuard = (_bb: BlackboardReader) => true;
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('loadWorkflow', () => {
+  // -----------------------------------------------------------------------
+  // Valid inputs
+  // -----------------------------------------------------------------------
+
+  describe('valid inputs', () => {
+    it('loads greeting.json from parsed object', () => {
+      const wf = loadWorkflow(parseFixture('greeting.json'));
+      expect(wf.id).toBe('greeting');
+      expect(wf.entry).toBe('ASK_NAME');
+      expect(Object.keys(wf.nodes)).toHaveLength(3);
+      expect(wf.edges).toHaveLength(2);
+    });
+
+    it('loads greeting.json from raw JSON string', () => {
+      const wf = loadWorkflow(readFixture('greeting.json'));
+      expect(wf.id).toBe('greeting');
+      expect(Object.keys(wf.nodes)).toHaveLength(3);
+    });
+
+    it('loads define-part-object.json with invocation spec', () => {
+      const wf = loadWorkflow(parseFixture('define-part-object.json'));
+      expect(wf.id).toBe('define-part-object');
+      expect(wf.entry).toBe('PART_CLASSIFY');
+      expect(Object.keys(wf.nodes)).toHaveLength(3);
+      expect(wf.edges).toHaveLength(2);
+    });
+
+    it('loads define-physical-object.json with builtin guards', () => {
+      const wf = loadWorkflow(
+        parseFixture('define-physical-object.json'),
+      );
+      expect(wf.id).toBe('define-physical-object');
+      expect(Object.keys(wf.nodes)).toHaveLength(6);
+      expect(wf.edges).toHaveLength(6);
+
+      // Check exists guard
+      const branchToPart = wf.edges.find(
+        (e) => e.id === 'e-branch-to-part',
+      )!;
+      expect(branchToPart.guard).toBeDefined();
+      const existsGuard = branchToPart.guard as BuiltinGuard;
+      expect(existsGuard.type).toBe('exists');
+      expect(existsGuard.key).toBe('needsPart');
+
+      // Check not-exists guard
+      const branchToSpec = wf.edges.find(
+        (e) => e.id === 'e-branch-to-spec',
+      )!;
+      expect(branchToSpec.guard).toBeDefined();
+      const notExistsGuard = branchToSpec.guard as BuiltinGuard;
+      expect(notExistsGuard.type).toBe('not-exists');
+      expect(notExistsGuard.key).toBe('needsPart');
+    });
+
+    it('preserves invocation spec on nodes', () => {
+      const wf = loadWorkflow(
+        parseFixture('define-physical-object.json'),
+      );
+      const definePart = wf.nodes['DEFINE_PART'];
+      expect(definePart.invokes).toBeDefined();
+      expect(definePart.invokes!.workflowId).toBe('define-part-object');
+      expect(definePart.invokes!.returnMap).toEqual([
+        { parentKey: 'Part Concept', childKey: 'partConcept' },
+      ]);
+    });
+
+    it('preserves node spec as freeform object', () => {
+      const wf = loadWorkflow(parseFixture('greeting.json'));
+      const askName = wf.nodes['ASK_NAME'];
+      expect(askName.spec).toEqual({
+        prompt: 'Ask the user for their name',
+        outputKey: 'userName',
+      });
+    });
+
+    it('preserves node description when present', () => {
+      const wf = loadWorkflow(parseFixture('greeting.json'));
+      expect(wf.nodes['GREET'].description).toBe(
+        'Generate a personalized greeting',
+      );
+    });
+
+    it('allows $schema field in input', () => {
+      // Fixtures include $schema — should not throw
+      const wf = loadWorkflow(parseFixture('greeting.json'));
+      expect(wf.id).toBe('greeting');
+    });
+
+    it('edges without guards have guard undefined', () => {
+      const wf = loadWorkflow(parseFixture('greeting.json'));
+      for (const edge of wf.edges) {
+        expect(edge.guard).toBeUndefined();
+      }
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Custom guard resolution
+  // -----------------------------------------------------------------------
+
+  describe('custom guard resolution', () => {
+    it('resolves custom guard from registry', () => {
+      const input = {
+        id: 'test',
+        entry: 'A',
+        nodes: {
+          A: { id: 'A', spec: {} },
+          B: { id: 'B', spec: {} },
+        },
+        edges: [
+          {
+            id: 'e1',
+            from: 'A',
+            to: 'B',
+            event: 'NEXT',
+            guard: { type: 'custom', name: 'myGuard' },
+          },
+        ],
+      };
+
+      const wf = loadWorkflow(input, { guards: { myGuard: stubGuard } });
+      const guard = wf.edges[0].guard as CustomGuard;
+      expect(guard.type).toBe('custom');
+      expect(guard.evaluate).toBe(stubGuard);
+    });
+
+    it('throws UNKNOWN_GUARD_REFERENCE for missing guard', () => {
+      const input = {
+        id: 'test',
+        entry: 'A',
+        nodes: {
+          A: { id: 'A', spec: {} },
+          B: { id: 'B', spec: {} },
+        },
+        edges: [
+          {
+            id: 'e1',
+            from: 'A',
+            to: 'B',
+            event: 'NEXT',
+            guard: { type: 'custom', name: 'nonExistent' },
+          },
+        ],
+      };
+
+      expect(() => loadWorkflow(input)).toThrow(WorkflowValidationError);
+      try {
+        loadWorkflow(input);
+      } catch (e) {
+        const err = e as WorkflowValidationError;
+        expect(err.code).toBe('UNKNOWN_GUARD_REFERENCE');
+        expect(err.workflowId).toBe('test');
+      }
+    });
+
+    it('throws UNKNOWN_GUARD_REFERENCE when registry provided but name missing', () => {
+      const input = {
+        id: 'test',
+        entry: 'A',
+        nodes: {
+          A: { id: 'A', spec: {} },
+          B: { id: 'B', spec: {} },
+        },
+        edges: [
+          {
+            id: 'e1',
+            from: 'A',
+            to: 'B',
+            event: 'NEXT',
+            guard: { type: 'custom', name: 'missing' },
+          },
+        ],
+      };
+
+      expect(() =>
+        loadWorkflow(input, { guards: { otherGuard: stubGuard } }),
+      ).toThrow(WorkflowValidationError);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Schema violations
+  // -----------------------------------------------------------------------
+
+  describe('schema violations', () => {
+    it('throws on invalid JSON string', () => {
+      expect(() => loadWorkflow('not valid json{')).toThrow(
+        WorkflowValidationError,
+      );
+      try {
+        loadWorkflow('not valid json{');
+      } catch (e) {
+        expect((e as WorkflowValidationError).code).toBe('SCHEMA_VIOLATION');
+      }
+    });
+
+    it('throws on missing id', () => {
+      const input = { entry: 'A', nodes: { A: { id: 'A', spec: {} } }, edges: [] };
+      expect(() => loadWorkflow(input)).toThrow(WorkflowValidationError);
+    });
+
+    it('throws on missing entry', () => {
+      const input = { id: 'x', nodes: { A: { id: 'A', spec: {} } }, edges: [] };
+      expect(() => loadWorkflow(input)).toThrow(WorkflowValidationError);
+    });
+
+    it('throws on missing nodes', () => {
+      const input = { id: 'x', entry: 'A', edges: [] };
+      expect(() => loadWorkflow(input)).toThrow(WorkflowValidationError);
+    });
+
+    it('throws on missing edges', () => {
+      const input = { id: 'x', entry: 'A', nodes: { A: { id: 'A', spec: {} } } };
+      expect(() => loadWorkflow(input)).toThrow(WorkflowValidationError);
+    });
+
+    it('throws when nodes is an array instead of object', () => {
+      const input = {
+        id: 'x',
+        entry: 'A',
+        nodes: [{ id: 'A', spec: {} }],
+        edges: [],
+      };
+      expect(() => loadWorkflow(input)).toThrow(WorkflowValidationError);
+    });
+
+    it('throws on unknown guard type', () => {
+      const input = {
+        id: 'x',
+        entry: 'A',
+        nodes: {
+          A: { id: 'A', spec: {} },
+          B: { id: 'B', spec: {} },
+        },
+        edges: [
+          {
+            id: 'e1',
+            from: 'A',
+            to: 'B',
+            event: 'NEXT',
+            guard: { type: 'bogus', key: 'x' },
+          },
+        ],
+      };
+      expect(() => loadWorkflow(input)).toThrow(WorkflowValidationError);
+    });
+
+    it('throws on non-object input', () => {
+      expect(() => loadWorkflow(42)).toThrow(WorkflowValidationError);
+    });
+
+    it('all schema violations use SCHEMA_VIOLATION code', () => {
+      const cases = [
+        { entry: 'A', nodes: {}, edges: [] }, // missing id
+        'not json{', // invalid JSON string
+        42, // non-object
+      ];
+
+      for (const input of cases) {
+        try {
+          loadWorkflow(input);
+        } catch (e) {
+          expect((e as WorkflowValidationError).code).toBe('SCHEMA_VIOLATION');
+        }
+      }
+    });
+  });
+});

--- a/typescript/src/loader.ts
+++ b/typescript/src/loader.ts
@@ -1,0 +1,196 @@
+// Reflex — Workflow Loader
+// Implements M7-2: Load and validate JSON workflow definitions
+
+import Ajv from 'ajv';
+import type {
+  BlackboardReader,
+  BuiltinGuard,
+  Edge,
+  Guard,
+  InvocationSpec,
+  Node,
+  NodeSpec,
+  Workflow,
+} from './types.js';
+import { WorkflowValidationError } from './registry.js';
+import { workflowSchema } from './workflow-schema.js';
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+/** Maps guard names (from JSON) to evaluate functions. */
+export type GuardRegistry = Record<
+  string,
+  (blackboard: BlackboardReader) => boolean
+>;
+
+/** Options for loadWorkflow. */
+export interface LoadWorkflowOptions {
+  guards?: GuardRegistry;
+}
+
+// ---------------------------------------------------------------------------
+// Schema validator (compiled once at module load)
+// ---------------------------------------------------------------------------
+
+const ajv = new Ajv({ allErrors: true });
+const validateSchema = ajv.compile(workflowSchema);
+
+// ---------------------------------------------------------------------------
+// Guard shapes from JSON (before resolution)
+// ---------------------------------------------------------------------------
+
+interface JsonBuiltinGuard {
+  type: 'exists' | 'not-exists' | 'equals' | 'not-equals';
+  key: string;
+  value?: unknown;
+}
+
+interface JsonCustomGuard {
+  type: 'custom';
+  name: string;
+}
+
+type JsonGuard = JsonBuiltinGuard | JsonCustomGuard;
+
+// ---------------------------------------------------------------------------
+// loadWorkflow
+// ---------------------------------------------------------------------------
+
+/**
+ * Parse and validate a JSON workflow definition, returning a typed Workflow.
+ *
+ * @param input - Raw JSON string or pre-parsed object
+ * @param options - Optional guard registry for resolving custom guard references
+ * @returns A fully typed Workflow with guards resolved
+ * @throws WorkflowValidationError on schema violations or missing guard references
+ */
+export function loadWorkflow(
+  input: unknown,
+  options?: LoadWorkflowOptions,
+): Workflow {
+  // 1. Parse if string
+  let data: unknown;
+  if (typeof input === 'string') {
+    try {
+      data = JSON.parse(input);
+    } catch (e) {
+      throw new WorkflowValidationError(
+        'SCHEMA_VIOLATION',
+        '<unknown>',
+        `Invalid JSON: ${(e as Error).message}`,
+      );
+    }
+  } else {
+    data = input;
+  }
+
+  // 2. Validate against schema
+  if (!validateSchema(data)) {
+    const errors = validateSchema.errors ?? [];
+    const detail = errors
+      .map((e) => `${e.instancePath || '/'}: ${e.message}`)
+      .join('; ');
+    throw new WorkflowValidationError(
+      'SCHEMA_VIOLATION',
+      '<unknown>',
+      `Schema validation failed: ${detail}`,
+      { errors },
+    );
+  }
+
+  // From here the data is structurally valid per the schema.
+  const raw = data as Record<string, unknown>;
+
+  const id = raw.id as string;
+  const entry = raw.entry as string;
+  const rawNodes = raw.nodes as Record<string, Record<string, unknown>>;
+  const rawEdges = raw.edges as Array<Record<string, unknown>>;
+  const metadata = raw.metadata as Record<string, unknown> | undefined;
+
+  // 3. Build nodes
+  const nodes: Record<string, Node> = {};
+  for (const [key, rawNode] of Object.entries(rawNodes)) {
+    const node: Node = {
+      id: rawNode.id as string,
+      spec: (rawNode.spec ?? {}) as NodeSpec,
+    };
+    if (rawNode.description !== undefined) {
+      node.description = rawNode.description as string;
+    }
+    if (rawNode.invokes !== undefined) {
+      const inv = rawNode.invokes as Record<string, unknown>;
+      node.invokes = {
+        workflowId: inv.workflowId as string,
+        returnMap: (inv.returnMap as Array<Record<string, string>>).map(
+          (rm) => ({
+            parentKey: rm.parentKey,
+            childKey: rm.childKey,
+          }),
+        ),
+      } satisfies InvocationSpec;
+    }
+    nodes[key] = node;
+  }
+
+  // 4. Build edges with guard resolution
+  const edges: Edge[] = rawEdges.map((rawEdge) => {
+    const edge: Edge = {
+      id: rawEdge.id as string,
+      from: rawEdge.from as string,
+      to: rawEdge.to as string,
+      event: rawEdge.event as string,
+    };
+
+    if (rawEdge.guard !== undefined) {
+      edge.guard = resolveGuard(
+        rawEdge.guard as JsonGuard,
+        id,
+        edge.id,
+        options?.guards,
+      );
+    }
+
+    return edge;
+  });
+
+  // 5. Assemble workflow
+  const workflow: Workflow = { id, entry, nodes, edges };
+  if (metadata !== undefined) {
+    workflow.metadata = metadata;
+  }
+
+  return workflow;
+}
+
+// ---------------------------------------------------------------------------
+// Guard resolution
+// ---------------------------------------------------------------------------
+
+function resolveGuard(
+  json: JsonGuard,
+  workflowId: string,
+  edgeId: string,
+  registry?: GuardRegistry,
+): Guard {
+  if (json.type === 'custom') {
+    const fn = registry?.[json.name];
+    if (!fn) {
+      throw new WorkflowValidationError(
+        'UNKNOWN_GUARD_REFERENCE',
+        workflowId,
+        `Edge '${edgeId}': custom guard '${json.name}' not found in guard registry`,
+        { edgeId, guardName: json.name },
+      );
+    }
+    return { type: 'custom', evaluate: fn };
+  }
+
+  // Builtin guard — pass through directly
+  const guard: BuiltinGuard = { type: json.type, key: json.key };
+  if ('value' in json && json.value !== undefined) {
+    guard.value = json.value;
+  }
+  return guard;
+}

--- a/typescript/src/registry.ts
+++ b/typescript/src/registry.ts
@@ -14,7 +14,9 @@ export type ValidationErrorCode =
   | 'NO_TERMINAL_NODES'
   | 'DUPLICATE_WORKFLOW_ID'
   | 'NODE_ID_MISMATCH'
-  | 'EMPTY_WORKFLOW';
+  | 'EMPTY_WORKFLOW'
+  | 'SCHEMA_VIOLATION'
+  | 'UNKNOWN_GUARD_REFERENCE';
 
 export class WorkflowValidationError extends Error {
   public readonly code: ValidationErrorCode;

--- a/typescript/src/workflow-schema.ts
+++ b/typescript/src/workflow-schema.ts
@@ -1,0 +1,149 @@
+// Runtime copy of docs/workflow-schema.json (JSON Schema draft-07).
+// Keep in sync with the canonical schema file.
+
+export const workflowSchema = {
+  $schema: 'http://json-schema.org/draft-07/schema#',
+  $id: 'https://github.com/corpus-relica/reflex/docs/workflow-schema.json',
+  title: 'Reflex Workflow',
+  type: 'object',
+  properties: {
+    $schema: { type: 'string' },
+    id: { type: 'string' },
+    entry: { type: 'string' },
+    nodes: {
+      type: 'object',
+      additionalProperties: { $ref: '#/definitions/Node' },
+    },
+    edges: {
+      type: 'array',
+      items: { $ref: '#/definitions/Edge' },
+    },
+    metadata: {
+      type: 'object',
+      additionalProperties: true,
+    },
+  },
+  required: ['id', 'entry', 'nodes', 'edges'],
+  additionalProperties: false,
+
+  definitions: {
+    Node: {
+      type: 'object',
+      properties: {
+        id: { type: 'string' },
+        description: { type: 'string' },
+        spec: { $ref: '#/definitions/NodeSpec' },
+        invokes: { $ref: '#/definitions/InvocationSpec' },
+      },
+      required: ['id', 'spec'],
+      additionalProperties: false,
+    },
+
+    NodeSpec: {
+      type: 'object',
+      additionalProperties: true,
+    },
+
+    InvocationSpec: {
+      type: 'object',
+      properties: {
+        workflowId: { type: 'string' },
+        returnMap: {
+          type: 'array',
+          items: { $ref: '#/definitions/ReturnMapping' },
+        },
+      },
+      required: ['workflowId', 'returnMap'],
+      additionalProperties: false,
+    },
+
+    ReturnMapping: {
+      type: 'object',
+      properties: {
+        parentKey: { type: 'string' },
+        childKey: { type: 'string' },
+      },
+      required: ['parentKey', 'childKey'],
+      additionalProperties: false,
+    },
+
+    Edge: {
+      type: 'object',
+      properties: {
+        id: { type: 'string' },
+        from: { type: 'string' },
+        to: { type: 'string' },
+        event: { type: 'string' },
+        guard: { $ref: '#/definitions/Guard' },
+      },
+      required: ['id', 'from', 'to', 'event'],
+      additionalProperties: false,
+    },
+
+    Guard: {
+      oneOf: [
+        {
+          type: 'object',
+          properties: {
+            type: { const: 'exists' },
+            key: { type: 'string' },
+          },
+          required: ['type', 'key'],
+          additionalProperties: false,
+        },
+        {
+          type: 'object',
+          properties: {
+            type: { const: 'not-exists' },
+            key: { type: 'string' },
+          },
+          required: ['type', 'key'],
+          additionalProperties: false,
+        },
+        {
+          type: 'object',
+          properties: {
+            type: { const: 'equals' },
+            key: { type: 'string' },
+            value: {
+              anyOf: [
+                { type: 'string' },
+                { type: 'number' },
+                { type: 'boolean' },
+                { type: 'null' },
+              ],
+            },
+          },
+          required: ['type', 'key', 'value'],
+          additionalProperties: false,
+        },
+        {
+          type: 'object',
+          properties: {
+            type: { const: 'not-equals' },
+            key: { type: 'string' },
+            value: {
+              anyOf: [
+                { type: 'string' },
+                { type: 'number' },
+                { type: 'boolean' },
+                { type: 'null' },
+              ],
+            },
+          },
+          required: ['type', 'key', 'value'],
+          additionalProperties: false,
+        },
+        {
+          type: 'object',
+          properties: {
+            type: { const: 'custom' },
+            name: { type: 'string' },
+          },
+          required: ['type', 'name'],
+          additionalProperties: false,
+        },
+      ],
+    },
+  },
+} as const;

--- a/typescript/yarn.lock
+++ b/typescript/yarn.lock
@@ -311,6 +311,16 @@
     loupe "^3.1.2"
     tinyrainbow "^1.2.0"
 
+ajv@^8.18.0:
+  version "8.18.0"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-8.18.0.tgz#8864186b6738d003eb3a933172bb3833e10cefbc"
+  integrity sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==
+  dependencies:
+    fast-deep-equal "^3.1.3"
+    fast-uri "^3.0.1"
+    json-schema-traverse "^1.0.0"
+    require-from-string "^2.0.2"
+
 assertion-error@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/assertion-error/-/assertion-error-2.0.1.tgz#f641a196b335690b1070bf00b6e7593fec190bf7"
@@ -395,10 +405,25 @@ expect-type@^1.1.0:
   resolved "https://registry.yarnpkg.com/expect-type/-/expect-type-1.3.0.tgz#0d58ed361877a31bbc4dd6cf71bbfef7faf6bd68"
   integrity sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==
 
+fast-deep-equal@^3.1.3:
+  version "3.1.3"
+  resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz#3a7d56b559d6cbc3eb512325244e619a65c6c525"
+  integrity sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==
+
+fast-uri@^3.0.1:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/fast-uri/-/fast-uri-3.1.0.tgz#66eecff6c764c0df9b762e62ca7edcfb53b4edfa"
+  integrity sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==
+
 fsevents@~2.3.2, fsevents@~2.3.3:
   version "2.3.3"
   resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.3.tgz#cac6407785d03675a2a5e1a5305c697b347d90d6"
   integrity sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==
+
+json-schema-traverse@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz#ae7bcb3656ab77a73ba5c49bf654f38e6b6860e2"
+  integrity sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==
 
 loupe@^3.1.0, loupe@^3.1.2:
   version "3.2.1"
@@ -445,6 +470,11 @@ postcss@^8.4.43:
     nanoid "^3.3.11"
     picocolors "^1.1.1"
     source-map-js "^1.2.1"
+
+require-from-string@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/require-from-string/-/require-from-string-2.0.2.tgz#89a7fdd938261267318eafe14f9c32e598c36909"
+  integrity sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==
 
 rollup@^4.20.0:
   version "4.57.1"


### PR DESCRIPTION
## Summary

Implements M7-2: a `loadWorkflow(json, options?)` function for both TypeScript and Go that validates JSON workflow definitions against the schema from M7-1 and returns typed `Workflow` objects with guards fully resolved.

## Issue Resolution

Closes #56

## Key Changes

- **TypeScript loader** (`typescript/src/loader.ts`): Uses `ajv` (new runtime dependency) for JSON Schema draft-07 validation. Accepts raw JSON strings or pre-parsed objects. Resolves custom guard names from a `GuardRegistry` map.
- **Go loader** (`go/loader.go`): Manual structural validation (stdlib only, zero external deps). Uses intermediate `jsonEdge` struct with `json.RawMessage` for guard deserialization since `Edge.Guard` is tagged `json:"-"`.
- **Error codes**: Extended `ValidationErrorCode` with `SCHEMA_VIOLATION` and `UNKNOWN_GUARD_REFERENCE` in both implementations.
- **Schema runtime copy** (`typescript/src/workflow-schema.ts`): TypeScript module exporting the JSON schema object, since `rootDir: "src"` prevents importing from `docs/`.
- **Test suites**: 21 TypeScript tests (vitest) + 14 Go tests covering fixtures, guard resolution, and schema violation cases.
- **Public API**: `loadWorkflow`, `GuardRegistry`, `LoadWorkflowOptions` exported from `index.ts`.

## Testing

- `yarn test` — 261 tests pass (10 test files)
- `go test ./...` — all tests pass
- All 3 fixture files from M7-1 load successfully
- Builtin guards (exists, not-exists) resolve correctly from fixtures
- Custom guard resolution and missing guard errors verified

## Checklist

- [x] TypeScript and Go implementations aligned
- [x] All acceptance criteria met
- [x] Tests cover valid inputs, schema violations, guard resolution
- [x] Public API exports added