### PR TITLE
feat(registry): Add verify() for static contract verification (#59)

### DIFF
--- a/go/registry.go
+++ b/go/registry.go
@@ -24,7 +24,36 @@ const (
 	ErrEmptyWorkflow          ValidationErrorCode = "EMPTY_WORKFLOW"
 	ErrSchemaViolation        ValidationErrorCode = "SCHEMA_VIOLATION"
 	ErrUnknownGuardReference  ValidationErrorCode = "UNKNOWN_GUARD_REFERENCE"
+	ErrWorkflowNotFound       ValidationErrorCode = "WORKFLOW_NOT_FOUND"
 )
+
+// ---------------------------------------------------------------------------
+// Verification Types (M8-2: Static Verification)
+// ---------------------------------------------------------------------------
+
+// VerificationWarningCode identifies the kind of contract verification warning.
+type VerificationWarningCode string
+
+const (
+	WarnMissingRequiredInput          VerificationWarningCode = "MISSING_REQUIRED_INPUT"
+	WarnReturnMapKeyNotInChildOutputs VerificationWarningCode = "RETURNMAP_KEY_NOT_IN_CHILD_OUTPUTS"
+)
+
+// VerificationWarning describes a single contract verification issue.
+type VerificationWarning struct {
+	Code       VerificationWarningCode
+	WorkflowID string
+	NodeID     string
+	Key        string
+	Message    string
+}
+
+// VerificationResult is the outcome of verify() — warnings and a valid flag.
+type VerificationResult struct {
+	WorkflowID string
+	Valid       bool
+	Warnings   []VerificationWarning
+}
 
 // ValidationError is returned when a workflow fails structural validation.
 type ValidationError struct {
@@ -116,6 +145,152 @@ func (r *Registry) List() []string {
 	}
 	sort.Strings(ids)
 	return ids
+}
+
+// Verify checks node contracts against DAG structure. Opt-in static analysis.
+func (r *Registry) Verify(workflowID string) (VerificationResult, error) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	w, ok := r.workflows[workflowID]
+	if !ok {
+		return VerificationResult{}, newValidationError(ErrWorkflowNotFound, workflowID,
+			fmt.Sprintf("cannot verify: workflow '%s' is not registered", workflowID))
+	}
+
+	var warnings []VerificationWarning
+	warnings = append(warnings, verifyInputContracts(w)...)
+	warnings = append(warnings, verifyReturnMaps(w, r)...)
+
+	return VerificationResult{
+		WorkflowID: workflowID,
+		Valid:      len(warnings) == 0,
+		Warnings:   warnings,
+	}, nil
+}
+
+// ---------------------------------------------------------------------------
+// Verification helpers
+// ---------------------------------------------------------------------------
+
+func topologicalOrderOf(w *Workflow) []string {
+	inDegree := make(map[string]int)
+	adjList := make(map[string][]string)
+	for id := range w.Nodes {
+		inDegree[id] = 0
+		adjList[id] = nil
+	}
+	for _, edge := range w.Edges {
+		adjList[edge.From] = append(adjList[edge.From], edge.To)
+		inDegree[edge.To]++
+	}
+
+	queue := make([]string, 0)
+	for id, deg := range inDegree {
+		if deg == 0 {
+			queue = append(queue, id)
+		}
+	}
+
+	var order []string
+	for len(queue) > 0 {
+		node := queue[0]
+		queue = queue[1:]
+		order = append(order, node)
+		for _, neighbor := range adjList[node] {
+			inDegree[neighbor]--
+			if inDegree[neighbor] == 0 {
+				queue = append(queue, neighbor)
+			}
+		}
+	}
+	return order
+}
+
+func terminalNodeIDsOf(w *Workflow) map[string]bool {
+	withOutgoing := make(map[string]bool)
+	for _, edge := range w.Edges {
+		withOutgoing[edge.From] = true
+	}
+	terminals := make(map[string]bool)
+	for id := range w.Nodes {
+		if !withOutgoing[id] {
+			terminals[id] = true
+		}
+	}
+	return terminals
+}
+
+func verifyInputContracts(w *Workflow) []VerificationWarning {
+	var warnings []VerificationWarning
+	order := topologicalOrderOf(w)
+	producedKeys := make(map[string]bool)
+
+	for _, nodeID := range order {
+		node := w.Nodes[nodeID]
+
+		for _, input := range node.Inputs {
+			if input.Required && !producedKeys[input.Key] {
+				warnings = append(warnings, VerificationWarning{
+					Code:       WarnMissingRequiredInput,
+					WorkflowID: w.ID,
+					NodeID:     nodeID,
+					Key:        input.Key,
+					Message:    fmt.Sprintf("node '%s' requires input '%s' but no upstream node declares it as an output", nodeID, input.Key),
+				})
+			}
+		}
+
+		for _, output := range node.Outputs {
+			producedKeys[output.Key] = true
+		}
+	}
+	return warnings
+}
+
+func verifyReturnMaps(w *Workflow, r *Registry) []VerificationWarning {
+	var warnings []VerificationWarning
+
+	for nodeID, node := range w.Nodes {
+		if node.Invokes == nil {
+			continue
+		}
+		subWf, ok := r.workflows[node.Invokes.WorkflowID]
+		if !ok {
+			continue
+		}
+
+		terminals := terminalNodeIDsOf(subWf)
+		childOutputKeys := make(map[string]bool)
+		anyTerminalHasOutputs := false
+
+		for termID := range terminals {
+			terminal := subWf.Nodes[termID]
+			if len(terminal.Outputs) > 0 {
+				anyTerminalHasOutputs = true
+				for _, output := range terminal.Outputs {
+					childOutputKeys[output.Key] = true
+				}
+			}
+		}
+
+		if !anyTerminalHasOutputs {
+			continue
+		}
+
+		for _, mapping := range node.Invokes.ReturnMap {
+			if !childOutputKeys[mapping.ChildKey] {
+				warnings = append(warnings, VerificationWarning{
+					Code:       WarnReturnMapKeyNotInChildOutputs,
+					WorkflowID: w.ID,
+					NodeID:     nodeID,
+					Key:        mapping.ChildKey,
+					Message:    fmt.Sprintf("node '%s' returnMap references child key '%s' not declared in sub-workflow '%s' terminal outputs", nodeID, mapping.ChildKey, node.Invokes.WorkflowID),
+				})
+			}
+		}
+	}
+	return warnings
 }
 
 // ---------------------------------------------------------------------------

--- a/typescript/src/index.ts
+++ b/typescript/src/index.ts
@@ -63,7 +63,12 @@ export type {
 
 export { WorkflowRegistry } from './registry.js';
 export { WorkflowValidationError } from './registry.js';
-export type { ValidationErrorCode } from './registry.js';
+export type {
+  ValidationErrorCode,
+  VerificationWarningCode,
+  VerificationWarning,
+  VerificationResult,
+} from './registry.js';
 
 export { ReflexEngine } from './engine.js';
 export { EngineError } from './engine.js';


### PR DESCRIPTION
## Summary
- Add opt-in `registry.verify(workflowId)` method for static contract verification against DAG structure
- Checks required inputs have upstream producers (via topological order forward-propagation)
- Checks returnMap child keys appear in sub-workflow terminal node outputs
- Returns `VerificationResult` with `valid` flag and `warnings` array
- Both TypeScript and Go implementations with full test coverage

## Issue Resolution
Closes #59

## Key Changes
- **TypeScript**: `verify()` method + `topologicalOrder()`/`terminalNodeIds()` private helpers on `WorkflowRegistry`, new `VerificationResult`/`VerificationWarning` types exported from public API
- **Go**: `Verify()` method on `*Registry` with `RLock` for thread safety, `topologicalOrderOf()`/`terminalNodeIDsOf()` package-level helpers
- **Tests**: 10 new tests per language covering all acceptance criteria (clean result, satisfied/missing required inputs, optional inputs, returnMap checks, unregistered workflows)

## Testing
- TypeScript: 299 tests passing (10 new verify tests)
- Go: All tests passing (10 new verify tests)