### PR TITLE
✨ feat(go/engine): Apply Decision.Writes on suspend (#97)

### DIFF
--- a/go/engine_test.go
+++ b/go/engine_test.go
@@ -1028,3 +1028,119 @@ func TestEngineInitSeedBlackboard(t *testing.T) {
 		}
 	})
 }
+
+// ---------------------------------------------------------------------------
+// Suspend writes — Decision.Writes must be applied on suspend
+// ---------------------------------------------------------------------------
+
+func TestSuspendWritesApplied(t *testing.T) {
+	r := NewRegistry()
+	_ = r.Register(linearWorkflow("wf"))
+
+	callCount := 0
+	agent := agentFunc(func(_ context.Context, dc DecisionContext) (Decision, error) {
+		callCount++
+		if dc.Node.ID == "A" && callCount == 1 {
+			// Suspend with writes — these must land on the blackboard
+			return Decision{
+				Type:   DecisionSuspend,
+				Reason: "batch progress",
+				Writes: []BlackboardWrite{
+					{Key: "progress", Value: 3},
+					{Key: "status", Value: "processing"},
+				},
+			}, nil
+		}
+		if len(dc.ValidEdges) == 0 {
+			return Decision{Type: DecisionComplete}, nil
+		}
+		return Decision{Type: DecisionAdvance, Edge: dc.ValidEdges[0].ID}, nil
+	})
+
+	e := NewEngine(r, agent)
+	_, _ = e.Init("wf")
+
+	// Step 1: suspend at A with writes
+	res, err := e.Step(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.Status != StepSuspended {
+		t.Fatalf("expected suspended, got %s", res.Status)
+	}
+
+	// Writes must be visible on the blackboard after suspend
+	bb := e.Blackboard()
+	progress, ok := bb.Get("progress")
+	if !ok {
+		t.Fatal("expected 'progress' key on blackboard after suspend with writes")
+	}
+	if progress != 3 {
+		t.Errorf("expected progress=3, got %v", progress)
+	}
+	status, ok := bb.Get("status")
+	if !ok {
+		t.Fatal("expected 'status' key on blackboard after suspend with writes")
+	}
+	if status != "processing" {
+		t.Errorf("expected status=processing, got %v", status)
+	}
+
+	// Step 2: resume → advance past A. Writes from suspend must persist.
+	res2, err := e.Step(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res2.Status != StepAdvanced {
+		t.Fatalf("expected advanced after resume, got %s", res2.Status)
+	}
+
+	// Writes still visible after advancing
+	bb2 := e.Blackboard()
+	if v, ok := bb2.Get("progress"); !ok || v != 3 {
+		t.Errorf("expected progress=3 after advance, got %v (ok=%v)", v, ok)
+	}
+}
+
+func TestSuspendWritesEmitBlackboardEvent(t *testing.T) {
+	r := NewRegistry()
+	_ = r.Register(linearWorkflow("wf"))
+
+	agent := agentFunc(func(_ context.Context, dc DecisionContext) (Decision, error) {
+		if dc.Node.ID == "A" {
+			return Decision{
+				Type:   DecisionSuspend,
+				Reason: "test",
+				Writes: []BlackboardWrite{{Key: "k", Value: "v"}},
+			}, nil
+		}
+		return Decision{Type: DecisionComplete}, nil
+	})
+
+	e := NewEngine(r, agent)
+
+	var bbEvents []Event
+	e.On(EventBlackboardWrite, func(ev Event) {
+		bbEvents = append(bbEvents, ev)
+	})
+
+	_, _ = e.Init("wf")
+	bbEventsAfterInit := len(bbEvents)
+
+	_, _ = e.Step(context.Background())
+
+	// Should have emitted a blackboard:write event for the suspend writes
+	if len(bbEvents) <= bbEventsAfterInit {
+		t.Fatal("expected blackboard:write event for suspend writes")
+	}
+	lastEvent := bbEvents[len(bbEvents)-1]
+	found := false
+	for _, entry := range lastEvent.Entries {
+		if entry.Key == "k" && entry.Value == "v" {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("blackboard:write event should contain the suspend writes")
+	}
+}

--- a/go/examples/suspend_writes_test.go
+++ b/go/examples/suspend_writes_test.go
@@ -1,0 +1,89 @@
+package examples
+
+import (
+	"context"
+	"testing"
+
+	reflex "github.com/corpus-relica/reflex/go"
+)
+
+// suspendAgent wraps a function as a DecisionAgent.
+type suspendAgent func(ctx context.Context, dc reflex.DecisionContext) (reflex.Decision, error)
+
+func (f suspendAgent) Resolve(ctx context.Context, dc reflex.DecisionContext) (reflex.Decision, error) {
+	return f(ctx, dc)
+}
+
+// TestSuspendWithWrites demonstrates that an agent can persist partial
+// progress on the blackboard when suspending.
+//
+// Use case: a batch analysis workflow processes 50 items. After item 25,
+// it needs to wait for an external API rate limit. The agent suspends
+// with writes recording the progress — so after resume, it knows where
+// to pick up.
+func TestSuspendWithWrites(t *testing.T) {
+	r := reflex.NewRegistry()
+	_ = r.Register(&reflex.Workflow{
+		ID:    "batch",
+		Entry: "PROCESS",
+		Nodes: map[string]*reflex.Node{
+			"PROCESS": {ID: "PROCESS", Spec: reflex.NodeSpec{}},
+			"DONE":    {ID: "DONE", Spec: reflex.NodeSpec{"complete": true}},
+		},
+		Edges: []reflex.Edge{
+			{ID: "e1", From: "PROCESS", To: "DONE", Event: "NEXT"},
+		},
+	})
+
+	callCount := 0
+	agent := suspendAgent(func(_ context.Context, dc reflex.DecisionContext) (reflex.Decision, error) {
+		callCount++
+		if callCount == 1 {
+			// First call: suspend with partial progress
+			return reflex.Decision{
+				Type:   reflex.DecisionSuspend,
+				Reason: "rate limit",
+				Writes: []reflex.BlackboardWrite{
+					{Key: "items_processed", Value: 25},
+					{Key: "last_item_id", Value: "item-025"},
+				},
+			}, nil
+		}
+		// Resume: finish and advance
+		if len(dc.ValidEdges) > 0 {
+			return reflex.Decision{Type: reflex.DecisionAdvance, Edge: dc.ValidEdges[0].ID}, nil
+		}
+		return reflex.Decision{Type: reflex.DecisionComplete}, nil
+	})
+
+	e := reflex.NewEngine(r, agent)
+	_, _ = e.Init("batch")
+
+	// Step 1: suspend with writes
+	res, _ := e.Step(context.Background())
+	if res.Status != reflex.StepSuspended {
+		t.Fatalf("expected suspended, got %s", res.Status)
+	}
+
+	// Partial progress is visible on the blackboard
+	bb := e.Blackboard()
+	processed, ok := bb.Get("items_processed")
+	if !ok || processed != 25 {
+		t.Errorf("expected items_processed=25, got %v (ok=%v)", processed, ok)
+	}
+	lastID, ok := bb.Get("last_item_id")
+	if !ok || lastID != "item-025" {
+		t.Errorf("expected last_item_id='item-025', got %v", lastID)
+	}
+
+	// Step 2: resume and complete
+	res, _ = e.Step(context.Background())
+	if res.Status != reflex.StepAdvanced {
+		t.Fatalf("expected advanced after resume, got %s", res.Status)
+	}
+
+	// Progress still visible after advancing
+	if v, ok := bb.Get("items_processed"); !ok || v != 25 {
+		t.Errorf("progress lost after resume: %v (ok=%v)", v, ok)
+	}
+}


### PR DESCRIPTION
## Problem

`Decision.Writes` are silently dropped when the agent returns `DecisionSuspend`. Only advance and complete decisions apply writes.

This is inconsistent with the `Decision` type definition — the `Writes` field is available to all decision types but only honored for two of them.

## Impact

Any workflow that suspends for external input (user interaction, API callback, rate limiting) cannot persist partial progress on the blackboard. The agent must re-derive state from scratch on resume or use out-of-band storage.

## Fix

Apply `Decision.Writes` to the blackboard (with `blackboard:write` event emission) **before** setting `StatusSuspended`. Same pattern used for advance and complete.

Backwards-compatible: agents that don't include `Writes` on suspend see no behavior change.

## Tests

- `TestSuspendWritesApplied` — writes visible on blackboard after suspend, persist through resume
- `TestSuspendWritesEmitBlackboardEvent` — `blackboard:write` event emitted for suspend writes
- `TestSuspendWithWrites` (example) — batch progress persistence use case

## Related

- #97 — Issue
- #83 / #85 — Cursor API (reads from the same blackboard suspend-writes populates)
- #87 — TS parity (same fix needed in TypeScript)