### PR TITLE
feat(ts/engine): Apply Decision.Writes on suspend (#97)

### DIFF
--- a/typescript/src/engine.test.ts
+++ b/typescript/src/engine.test.ts
@@ -564,6 +564,67 @@ describe('ReflexEngine', () => {
         'awaiting input',
       );
     });
+
+    it('persists writes to blackboard when suspending with writes', async () => {
+      registry.register(linearWorkflow());
+      const resolveFn = vi
+        .fn()
+        .mockResolvedValueOnce({
+          type: 'suspend',
+          reason: 'rate limit',
+          writes: [
+            { key: 'progress', value: 25 },
+            { key: 'status', value: 'processing' },
+          ],
+        });
+      const engine = new ReflexEngine(registry, makeAgent(resolveFn));
+
+      await engine.init('linear');
+      const result = await engine.step();
+
+      expect(result.status).toBe('suspended');
+      expect(engine.blackboard().get('progress')).toBe(25);
+      expect(engine.blackboard().get('status')).toBe('processing');
+    });
+
+    it('emits blackboard:write event before engine:suspend when writes present', async () => {
+      registry.register(linearWorkflow());
+      const resolveFn = vi.fn().mockResolvedValueOnce({
+        type: 'suspend',
+        reason: 'test',
+        writes: [{ key: 'k', value: 'v' }],
+      });
+      const engine = new ReflexEngine(registry, makeAgent(resolveFn));
+
+      const events: string[] = [];
+      engine.on('blackboard:write', () => events.push('blackboard:write'));
+      engine.on('engine:suspend', () => events.push('engine:suspend'));
+
+      await engine.init('linear');
+      await engine.step();
+
+      expect(events).toEqual(['blackboard:write', 'engine:suspend']);
+    });
+
+    it('suspend writes are still visible on blackboard after resume and advance', async () => {
+      registry.register(linearWorkflow());
+      const resolveFn = vi
+        .fn()
+        .mockResolvedValueOnce({
+          type: 'suspend',
+          reason: 'rate limit',
+          writes: [{ key: 'progress', value: 25 }],
+        })
+        .mockResolvedValueOnce({ type: 'advance', edge: 'e-ab' });
+      const engine = new ReflexEngine(registry, makeAgent(resolveFn));
+
+      await engine.init('linear');
+      await engine.step(); // suspend with writes
+      await engine.step(); // resume → advance
+
+      expect(engine.status()).toBe('running');
+      expect(engine.blackboard().get('progress')).toBe(25);
+    });
   });
 
   // -----------------------------------------------------------------------

--- a/typescript/src/engine.ts
+++ b/typescript/src/engine.ts
@@ -281,6 +281,18 @@ export class ReflexEngine {
 
     // -- Handle suspend -----------------------------------------------------
     if (decision.type === 'suspend') {
+      if (decision.writes && decision.writes.length > 0) {
+        const source: BlackboardSource = {
+          workflowId: this._currentWorkflowId,
+          nodeId: this._currentNodeId,
+          stackDepth: this._stack.length,
+        };
+        const newEntries = this._currentBlackboard.append(
+          decision.writes,
+          source,
+        );
+        this._emit('blackboard:write', { entries: newEntries, workflow });
+      }
       this._status = 'suspended';
       this._emit('engine:suspend', {
         reason: decision.reason,

--- a/typescript/src/types.ts
+++ b/typescript/src/types.ts
@@ -201,7 +201,7 @@ export interface DecisionContext {
 
 export type Decision =
   | { type: 'advance'; edge: string; writes?: BlackboardWrite[] }
-  | { type: 'suspend'; reason: string }
+  | { type: 'suspend'; reason: string; writes?: BlackboardWrite[] }
   | { type: 'complete'; writes?: BlackboardWrite[] };
 
 export interface DecisionAgent {


### PR DESCRIPTION
## Summary

- Apply `Decision.Writes` to the blackboard when an agent returns `suspend` with writes, before transitioning to suspended status
- TypeScript parity for the Go fix (commit `4dddedd`)

Closes #97

## Key Changes

- **`types.ts`**: Added optional `writes?: BlackboardWrite[]` to the suspend variant of the `Decision` union type
- **`engine.ts`**: Insert write-application and `blackboard:write` event emission in the suspend block, before `this._status = 'suspended'` — same pattern as advance and complete
- **`engine.test.ts`**: 3 new tests — writes applied on suspend, event ordering (`blackboard:write` before `engine:suspend`), writes persist after resume

## Test plan

- [x] 380 tests passing (377 existing + 3 new)
- [x] Backwards-compatible: existing suspend-without-writes tests unchanged
- [x] Event ordering verified: `blackboard:write` fires before `engine:suspend`