### PR TITLE
chore(release): Prepare TypeScript v1.0.0 (#70)

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Reflex provides a formally characterized execution model (Chomsky Type 1, contex
 
 | Language | Directory | Package | Status |
 |----------|-----------|---------|--------|
-| TypeScript | [`typescript/`](typescript/) | `@corpus-relica/reflex` | v0.6.1 — 380 tests, ESM + CJS |
+| TypeScript | [`typescript/`](typescript/) | `@corpus-relica/reflex` | v1.0.0 — 380 tests, ESM + CJS, stable API |
 | Go | [`go/`](go/) | `github.com/corpus-relica/reflex/go` | v0.3.0 — 158 tests, stdlib only, zero dependencies |
 
 Both implementations conform to the shared [DESIGN.md](docs/DESIGN.md) specification. They are independent codebases targeting the same formal model.
@@ -62,7 +62,8 @@ Reflex implements a pushdown automaton with append-only tape — equivalent to a
 ## Documentation
 
 - [DESIGN.md](docs/DESIGN.md) — Formal model, core types, runtime architecture, extension points, boundaries
-- [ROADMAP-v1.md](docs/ROADMAP-v1.md) — V1.0 roadmap (4 milestones, 12 issues: declarative workflows, node contracts, persistence, API stabilization)
+- [MIGRATION-v1.md](docs/MIGRATION-v1.md) — Upgrade guide from v0.x to v1.0
+- [ROADMAP-v1.md](docs/ROADMAP-v1.md) — V1.0 roadmap (4 milestones, 12 issues) — completed
 - [ROADMAP-v-alpha.md](docs/ROADMAP-v-alpha.md) — V-alpha implementation plan (6 milestones, 24 issues) — completed
 
 ## License

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -529,7 +529,7 @@ The following items from v-alpha's deferred list are now planned for v1.0 (see [
 
 These are deliberate non-goals of the Reflex engine — not deferred, but excluded by design:
 
-- **Parallel execution / fork-join**: The formal model is a pushdown automaton with a single program counter. Fork/join introduces concurrent program counters, fundamentally changing what "step" means and breaking the deterministic trace property. Consumers who need concurrency handle it in their agent or application code — Reflex orchestrates the sequential decision path, not the parallel execution.
+- **Parallel execution / fork-join**: Excluded by design — see Section 7 for the full rationale. Consumers who need concurrency handle it in their agent or application code.
 - **Built-in decision agents**: Reflex provides the interface, not implementations. LLM agents, rule engines, human UIs — these are consumer concerns.
 - **Built-in persistence adapters**: Reflex defines the snapshot format and adapter interface. Consumers provide their own storage (file, database, etc.).
 - **Distributed execution**: Engine instances across processes or machines. Reflex is a single-process, single-session engine.
@@ -542,6 +542,34 @@ The following remain interesting but are not planned for v1.0:
 - **Edge exhaustiveness checks**: Static verification that all possible blackboard states at a fan-out point are covered by guards
 - **Parent-to-child value passing**: Explicit push of specific parent values into child scope on invocation (currently unnecessary because child can read parent scope via the scope chain)
 - **Hot-reload workflows**: Swap workflow definition mid-execution
+
+---
+
+## 7. Design Rationale: The Single-Thread Invariant
+
+Reflex deliberately excludes parallel execution (fork/join). This is not a limitation to be solved later — it is a design principle that preserves the formal properties described in Section 1.
+
+### 7.1 The Formal Argument
+
+Reflex implements a pushdown automaton with a **single program counter**. At any point during execution, exactly one node is active, exactly one step resolution is in progress, and exactly one transition is being evaluated. This is the single-thread invariant.
+
+Fork/join would require **multiple simultaneous program counters** — several nodes active at once, each producing blackboard writes independently. This changes the system in three ways:
+
+1. **"Step" becomes ambiguous.** With one program counter, `step()` means "advance the single active node and resolve the next transition." With concurrent branches, `step()` must either advance all branches (losing per-node granularity) or advance one branch (requiring a scheduler, introducing nondeterminism in execution order).
+
+2. **The deterministic trace property breaks.** With serial execution, the sequence of events (`node:enter`, `blackboard:write`, `node:exit`) is fully determined by the workflow graph and decision agent responses. With concurrent branches, the interleaving of events across branches depends on scheduling — the same inputs can produce different event orderings.
+
+3. **Blackboard coherence degrades.** The append-only blackboard's guarantee — that established context is never contradicted, only superseded — depends on a total ordering of writes. Concurrent branches writing to the same key create an ordering ambiguity: which write is "later"? Resolving this requires either a conflict resolution policy (complexity) or isolated branch-local blackboards (breaking the shared-context model that makes Reflex context-sensitive).
+
+### 7.2 The Practical Consequence
+
+Consumers who need concurrent execution have two clean options:
+
+- **Concurrency in the agent.** The decision agent can spawn parallel work internally (HTTP requests, LLM calls, database queries) and return a single decision. The engine sees a single synchronous step; the parallelism is invisible to the formal model.
+
+- **Concurrency above the engine.** Run multiple independent engine instances in parallel, each with its own workflow and blackboard. Coordinate results in application code. This preserves the per-engine formal properties while allowing system-level parallelism.
+
+Both approaches keep the engine's formal model intact. Reflex orchestrates the sequential decision path — the consumer decides where parallelism lives.
 
 ---
 

--- a/typescript/README.md
+++ b/typescript/README.md
@@ -179,11 +179,12 @@ while (true) {
 
 ## Status
 
-**v0.6.1** — 380 tests passing. ESM + CJS dual output.
+**v1.0.0** — 380 tests passing. ESM + CJS dual output. Stable public API.
 
 ## Documentation
 
 - [DESIGN.md](../docs/DESIGN.md) — Formal model, core types, runtime architecture, extension points, boundaries
+- [MIGRATION-v1.md](../docs/MIGRATION-v1.md) — Upgrade guide from v0.x to v1.0
 - [ROADMAP-v-alpha.md](../docs/ROADMAP-v-alpha.md) — V-alpha implementation plan (6 milestones, 24 issues) — completed
 
 ## License
@@ -191,6 +192,8 @@ while (true) {
 MIT — see [LICENSE](../LICENSE)
 
 ## Changelog
+
+**v1.0.0** — First stable release. Public API locked — breaking changes require a major version bump. All M7–M10 milestones complete: declarative workflows (`loadWorkflow`, `serializeWorkflow`, JSON Schema), node contracts (`inputs`/`outputs` on nodes, `registry.verify()`), persistence (`engine.snapshot()`, `restoreEngine()`), cursor API (`currentBlackboard()`, `entriesFrom()`). JSDoc on all public symbols. 380 tests. See [MIGRATION-v1.md](../docs/MIGRATION-v1.md) for the upgrade guide.
 
 **v0.6.1** — Bug fix: `Decision.Writes` on suspend are now applied to the blackboard (previously silently dropped). `blackboard:write` event emitted before `engine:suspend`. 380 tests.
 

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@corpus-relica/reflex",
-  "version": "0.6.1",
+  "version": "1.0.0",
   "description": "DAG-based workflow orchestration with call stack composition and append-only blackboard semantics",
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
## Summary

Release preparation for TypeScript v1.0.0 — the first stable release of `@corpus-relica/reflex`.

- Add Section 7 to DESIGN.md: "The Single-Thread Invariant" — formal rationale for excluding fork/join
- Bump `typescript/package.json` to `1.0.0`
- Update `typescript/README.md`: status, v1.0.0 changelog entry, migration guide link
- Update root `README.md`: version table, roadmap completion status, migration guide link

## Issue Resolution

Closes #70 (partially — tag, npm publish, and GitHub release to follow after merge)

## Post-Merge Steps

After this PR merges:
1. `git tag -a typescript/v1.0.0 -m "M10: API Stabilization (TypeScript)"`
2. `git push origin typescript/v1.0.0`
3. `cd typescript && npm publish --access public`
4. `gh release create typescript/v1.0.0` with changelog

## Testing

All 380 TypeScript tests pass. Doc-only + version bump changes.