### PR TITLE
feat(engine): Add reinvoke option to unwindToDepth

### DIFF
--- a/typescript/src/engine.ts
+++ b/typescript/src/engine.ts
@@ -25,6 +25,7 @@ import {
   EngineStatus,
   EngineSnapshot,
   InitOptions,
+  UnwindOptions,
   CursorReader,
 } from './types.js';
 import { WorkflowRegistry } from './registry.js';
@@ -614,10 +615,14 @@ export class ReflexEngine {
    * The engine remains in `suspended` state after unwind — call
    * {@link run} or {@link step} to resume execution at the target node.
    *
+   * @param options.reinvoke — When `true`, the restored frame's invocation
+   *   node will re-trigger its sub-workflow on the next step() rather than
+   *   advancing past it. Defaults to `false`.
+   *
    * @throws {EngineError} If called before init(), not in `suspended`
    *   state, or `n` is out of range.
    */
-  unwindToDepth(n: number): void {
+  unwindToDepth(n: number, options?: UnwindOptions): void {
     if (
       this._sessionId === null ||
       this._currentWorkflowId === null ||
@@ -659,8 +664,9 @@ export class ReflexEngine {
     this._stack = this._stack.slice(targetIdx + 1);
 
     // The target node is an invocation node (frames are only pushed at
-    // invocation nodes). Skip re-triggering the sub-workflow on resume.
-    this._skipInvocation = true;
+    // invocation nodes). By default, skip re-triggering the sub-workflow
+    // on resume. When reinvoke is true, allow re-invocation instead.
+    this._skipInvocation = options?.reinvoke !== true;
   }
 
   // -------------------------------------------------------------------------

--- a/typescript/src/index.ts
+++ b/typescript/src/index.ts
@@ -65,6 +65,7 @@ export type {
   RunResult,
   EventHandler,
   InitOptions,
+  UnwindOptions,
   EngineSnapshot,
   GuardRegistry,
   RestoreOptions,

--- a/typescript/src/types.ts
+++ b/typescript/src/types.ts
@@ -208,6 +208,18 @@ export interface InitOptions {
   blackboard?: BlackboardWrite[];
 }
 
+/**
+ * Options for {@link ReflexEngine.unwindToDepth | engine.unwindToDepth()}.
+ *
+ * `reinvoke`: when `true`, the restored frame's invocation node will
+ * re-trigger its sub-workflow on the next step() instead of running
+ * normal edge logic. Defaults to `false` (skip re-invocation, advance
+ * past the invocation node).
+ */
+export interface UnwindOptions {
+  reinvoke?: boolean;
+}
+
 // ---------------------------------------------------------------------------
 // 2.9 Call Stack
 // ---------------------------------------------------------------------------

--- a/typescript/src/unwind.test.ts
+++ b/typescript/src/unwind.test.ts
@@ -401,4 +401,59 @@ describe('unwindToDepth', () => {
       expect(snap.skipInvocation).toBe(true);
     });
   });
+
+  // -------------------------------------------------------------------------
+  // reinvoke option
+  // -------------------------------------------------------------------------
+
+  describe('reinvoke option', () => {
+    it('{ reinvoke: false } behaves like default — skipInvocation is true', async () => {
+      const { engine } = await setupSuspendedAtDepth3();
+
+      engine.unwindToDepth(1, { reinvoke: false });
+
+      const snap = engine.snapshot();
+      expect(snap.skipInvocation).toBe(true);
+    });
+
+    it('{ reinvoke: true } sets skipInvocation to false in snapshot', async () => {
+      const { engine } = await setupSuspendedAtDepth3();
+
+      engine.unwindToDepth(1, { reinvoke: true });
+
+      const snap = engine.snapshot();
+      expect(snap.skipInvocation).toBe(false);
+    });
+
+    it('{ reinvoke: true } causes re-invocation on next step()', async () => {
+      const { engine, resolveFn } = await setupSuspendedAtDepth3();
+
+      engine.unwindToDepth(1, { reinvoke: true });
+
+      // mid is now active at MID_INVOKE. With reinvoke, step() should
+      // re-invoke the 'deep' sub-workflow instead of consulting the agent.
+      const result = await engine.step();
+
+      expect(result.status).toBe('invoked');
+      expect(engine.currentWorkflow()!.id).toBe('deep');
+      expect(engine.currentNode()!.id).toBe('DEEP_INIT');
+      // Agent was called 3 times during setup, NOT called during re-invocation
+      expect(resolveFn).toHaveBeenCalledTimes(3);
+    });
+
+    it('no-op path with { reinvoke: true } does not alter skipInvocation', async () => {
+      const { engine } = await setupSuspendedAtDepth3();
+
+      // Capture current skipInvocation via snapshot before the no-op
+      const snapBefore = engine.snapshot();
+
+      // n === stack.length (2) is a no-op
+      engine.unwindToDepth(2, { reinvoke: true });
+
+      const snapAfter = engine.snapshot();
+      expect(snapAfter.skipInvocation).toBe(snapBefore.skipInvocation);
+      expect(engine.currentWorkflow()!.id).toBe('deep');
+      expect(engine.currentNode()!.id).toBe('DEEP_INIT');
+    });
+  });
 });


### PR DESCRIPTION
## Summary

- Adds optional `{ reinvoke: true }` flag to `unwindToDepth(n, options?)` 
- When set, the restored invocation node re-triggers its sub-workflow instead of advancing past it
- Enables breadcrumb navigation semantics: unwind to a prior frame and restart its sub-workflow from scratch
- Default behavior unchanged — fully backward compatible

## Changes

- `types.ts` — New `UnwindOptions` interface with `reinvoke?: boolean`
- `engine.ts` — Updated signature, one conditional line change, updated comments/JSDoc
- `index.ts` — Export `UnwindOptions`
- `unwind.test.ts` — 4 new tests (400 total passing)

## Test plan

- [x] `{ reinvoke: false }` matches default behavior (`skipInvocation: true`)
- [x] `{ reinvoke: true }` sets `skipInvocation: false` in snapshot
- [x] `{ reinvoke: true }` causes actual re-invocation on next `step()`
- [x] No-op path (`n === stack.length`) with `{ reinvoke: true }` leaves state unchanged
- [x] All 400 tests pass, type check clean

Closes #108