### PR TITLE
fix(engine): Emit stack:unwind event from unwindToDepth

### DIFF
--- a/typescript/src/engine.ts
+++ b/typescript/src/engine.ts
@@ -26,6 +26,7 @@ import {
   EngineSnapshot,
   InitOptions,
   UnwindOptions,
+  UnwindEvent,
   CursorReader,
 } from './types.js';
 import { WorkflowRegistry } from './registry.js';
@@ -652,6 +653,21 @@ export class ReflexEngine {
     const targetIdx = this._stack.length - 1 - n;
     const targetFrame = this._stack[targetIdx];
 
+    // Capture frames to discard BEFORE mutating state.
+    // Build a synthetic StackFrame for the active layer (not on _stack).
+    const activeFrameSnapshot: StackFrame = {
+      workflowId: this._currentWorkflowId,
+      currentNodeId: this._currentNodeId,
+      returnMap: [],
+      blackboard: [
+        ...this._currentBlackboard.getEntries(),
+      ] as BlackboardEntry[],
+    };
+    const discardedFrames = [
+      activeFrameSnapshot,
+      ...this._stack.slice(0, targetIdx),
+    ];
+
     // Restore target frame as active context.
     // Reconstruct blackboard from frozen snapshot (mirrors pop path).
     this._currentWorkflowId = targetFrame.workflowId;
@@ -666,7 +682,19 @@ export class ReflexEngine {
     // The target node is an invocation node (frames are only pushed at
     // invocation nodes). By default, skip re-triggering the sub-workflow
     // on resume. When reinvoke is true, allow re-invocation instead.
-    this._skipInvocation = options?.reinvoke !== true;
+    const reinvoke = options?.reinvoke === true;
+    this._skipInvocation = !reinvoke;
+
+    // Emit stack:unwind so listeners (devtools, logging) can stay in sync.
+    const restoredWorkflow = this._registry.get(this._currentWorkflowId)!;
+    const restoredNode = restoredWorkflow.nodes[this._currentNodeId]!;
+    this._emit('stack:unwind', {
+      discardedFrames,
+      targetDepth: n,
+      restoredWorkflow,
+      restoredNode,
+      reinvoke,
+    } satisfies UnwindEvent);
   }
 
   // -------------------------------------------------------------------------

--- a/typescript/src/index.ts
+++ b/typescript/src/index.ts
@@ -66,6 +66,7 @@ export type {
   EventHandler,
   InitOptions,
   UnwindOptions,
+  UnwindEvent,
   EngineSnapshot,
   GuardRegistry,
   RestoreOptions,

--- a/typescript/src/types.ts
+++ b/typescript/src/types.ts
@@ -365,10 +365,24 @@ export type EngineEvent =
   | 'edge:traverse'
   | 'workflow:push'
   | 'workflow:pop'
+  | 'stack:unwind'
   | 'blackboard:write'
   | 'engine:complete'
   | 'engine:suspend'
   | 'engine:error';
+
+/**
+ * Payload for the `stack:unwind` event, emitted by
+ * {@link ReflexEngine.unwindToDepth | engine.unwindToDepth()}.
+ * Contains the discarded frames and the restored execution context.
+ */
+export interface UnwindEvent {
+  discardedFrames: StackFrame[];
+  targetDepth: number;
+  restoredWorkflow: Workflow;
+  restoredNode: Node;
+  reinvoke: boolean;
+}
 
 // ---------------------------------------------------------------------------
 // 3.2 Execution Engine — EngineStatus, RunResult, EventHandler

--- a/typescript/src/unwind.test.ts
+++ b/typescript/src/unwind.test.ts
@@ -192,14 +192,100 @@ describe('unwindToDepth', () => {
   });
 
   // -------------------------------------------------------------------------
-  // No events emitted
+  // stack:unwind event
   // -------------------------------------------------------------------------
 
-  describe('no events emitted', () => {
-    it('does not emit any events during unwind', async () => {
+  describe('stack:unwind event', () => {
+    it('emits exactly one stack:unwind event on real unwind', async () => {
       const { engine } = await setupSuspendedAtDepth3();
 
-      const allEvents: EngineEvent[] = [
+      const payloads: unknown[] = [];
+      engine.on('stack:unwind', (p) => payloads.push(p));
+
+      engine.unwindToDepth(0);
+
+      expect(payloads).toHaveLength(1);
+    });
+
+    it('does not emit stack:unwind on no-op (n === stack.length)', async () => {
+      const { engine } = await setupSuspendedAtDepth3();
+
+      const payloads: unknown[] = [];
+      engine.on('stack:unwind', (p) => payloads.push(p));
+
+      engine.unwindToDepth(2); // stack.length is 2 — no-op
+
+      expect(payloads).toHaveLength(0);
+    });
+
+    it('payload has correct targetDepth', async () => {
+      const { engine } = await setupSuspendedAtDepth3();
+
+      let payload: any;
+      engine.on('stack:unwind', (p) => { payload = p; });
+
+      engine.unwindToDepth(1);
+
+      expect(payload.targetDepth).toBe(1);
+    });
+
+    it('payload discardedFrames includes active frame and intermediate frames', async () => {
+      const { engine } = await setupSuspendedAtDepth3();
+
+      let payload: any;
+      engine.on('stack:unwind', (p) => { payload = p; });
+
+      // Unwind from depth 2 (deep active, stack=[mid, gp]) to depth 0
+      // Discarded: active (deep) + mid frame = 2 frames
+      engine.unwindToDepth(0);
+
+      expect(payload.discardedFrames).toHaveLength(2);
+      // Active frame (deep) comes first
+      expect(payload.discardedFrames[0].workflowId).toBe('deep');
+      expect(payload.discardedFrames[0].currentNodeId).toBe('DEEP_INIT');
+      // Then the mid frame
+      expect(payload.discardedFrames[1].workflowId).toBe('mid');
+      expect(payload.discardedFrames[1].currentNodeId).toBe('MID_INVOKE');
+    });
+
+    it('payload has correct restoredWorkflow and restoredNode', async () => {
+      const { engine } = await setupSuspendedAtDepth3();
+
+      let payload: any;
+      engine.on('stack:unwind', (p) => { payload = p; });
+
+      engine.unwindToDepth(1);
+
+      expect(payload.restoredWorkflow.id).toBe('mid');
+      expect(payload.restoredNode.id).toBe('MID_INVOKE');
+    });
+
+    it('payload reinvoke is false by default', async () => {
+      const { engine } = await setupSuspendedAtDepth3();
+
+      let payload: any;
+      engine.on('stack:unwind', (p) => { payload = p; });
+
+      engine.unwindToDepth(1);
+
+      expect(payload.reinvoke).toBe(false);
+    });
+
+    it('payload reinvoke is true when { reinvoke: true } passed', async () => {
+      const { engine } = await setupSuspendedAtDepth3();
+
+      let payload: any;
+      engine.on('stack:unwind', (p) => { payload = p; });
+
+      engine.unwindToDepth(1, { reinvoke: true });
+
+      expect(payload.reinvoke).toBe(true);
+    });
+
+    it('does not emit workflow:pop, node:enter, or node:exit during unwind', async () => {
+      const { engine } = await setupSuspendedAtDepth3();
+
+      const otherEvents: EngineEvent[] = [
         'node:enter',
         'node:exit',
         'edge:traverse',
@@ -211,7 +297,7 @@ describe('unwindToDepth', () => {
         'engine:error',
       ];
       const fired: EngineEvent[] = [];
-      for (const evt of allEvents) {
+      for (const evt of otherEvents) {
         engine.on(evt, () => fired.push(evt));
       }
 


### PR DESCRIPTION
## Summary

- `unwindToDepth` now emits a `stack:unwind` event after modifying the stack, so devtools and other listeners can stay in sync
- New `UnwindEvent` payload type with `discardedFrames`, `targetDepth`, `restoredWorkflow`, `restoredNode`, and `reinvoke`
- No event emitted on no-op (`n === stack.length`)
- Existing events (`workflow:pop`, `node:enter`, etc.) remain silent during unwind — semantic boundary preserved

## Design Decision

Chose a dedicated `stack:unwind` event (issue option 2) over emitting `workflow:pop` per frame (option 1) or a full snapshot re-sync (option 3). The semantics differ from normal pop — no returnMap processing, multiple frames at once — so a distinct event is cleanest.

## Test plan

- [x] Emits exactly one `stack:unwind` event on real unwind
- [x] No `stack:unwind` on no-op (`n === stack.length`)
- [x] Payload `targetDepth` matches `n`
- [x] Payload `discardedFrames` has correct count and content (active frame + intermediates)
- [x] Payload `restoredWorkflow` and `restoredNode` are correct
- [x] Payload `reinvoke` reflects the option passed
- [x] No `workflow:pop`, `node:enter`, `node:exit` emitted during unwind
- [x] All 407 tests pass, type check clean

Closes #110