### PR TITLE
Add imperative pushWorkflow() and popWorkflow()

### DIFF
--- a/typescript/src/engine.ts
+++ b/typescript/src/engine.ts
@@ -28,6 +28,7 @@ import {
   UnwindOptions,
   UnwindEvent,
   CursorReader,
+  PushWorkflowOptions,
 } from './types.js';
 import { WorkflowRegistry } from './registry.js';
 import { ScopedBlackboard, ScopedBlackboardReader } from './blackboard.js';
@@ -695,6 +696,184 @@ export class ReflexEngine {
       restoredNode,
       reinvoke,
     } satisfies UnwindEvent);
+  }
+
+  // -------------------------------------------------------------------------
+  // Imperative Push/Pop
+  // -------------------------------------------------------------------------
+
+  /**
+   * Programmatically push a sub-workflow onto the call stack. The current
+   * workflow/node/blackboard is saved in a {@link StackFrame} and the engine
+   * switches to the sub-workflow's entry node.
+   *
+   * This complements the declarative {@link InvocationSpec | node.invokes}
+   * mechanism — use it when invocation is driven by external code (e.g.,
+   * user clicks "Create New") rather than the graph structure.
+   *
+   * Note: The issue proposal describes async `Promise<StepResult>` but
+   * push/pop are synchronous — no agent resolution or async work occurs.
+   *
+   * @param options.inputMap — Seed the child blackboard with parent values
+   *   at push time. Each mapping reads `from` in the parent scope and
+   *   writes to `to` in the child's local scope (additive seeding, not
+   *   parent-key isolation).
+   * @param options.returnMap — Propagate child values back to the parent
+   *   on {@link popWorkflow}.
+   *
+   * @throws {EngineError} If called before init(), in completed/error
+   *   state, or if the workflow is not registered.
+   */
+  pushWorkflow(workflowId: string, options?: PushWorkflowOptions): StepResult {
+    // -- Precondition guards ------------------------------------------------
+    if (
+      this._currentWorkflowId === null ||
+      this._currentNodeId === null ||
+      this._currentBlackboard === null
+    ) {
+      throw new EngineError('pushWorkflow() called before init()');
+    }
+    if (this._status !== 'running' && this._status !== 'suspended') {
+      throw new EngineError(
+        `pushWorkflow() called in invalid state: '${this._status}' — engine must be 'running' or 'suspended'`,
+      );
+    }
+
+    const subWorkflow = this._registry.get(workflowId);
+    if (!subWorkflow) {
+      throw new EngineError(
+        `pushWorkflow() failed: workflow '${workflowId}' is not registered`,
+      );
+    }
+
+    // Capture parent reader BEFORE mutating the stack — needed for inputMap
+    // reads and must reflect the pre-push scope chain.
+    const parentReader = this.blackboard();
+
+    // Push current frame onto the stack
+    const frame: StackFrame = {
+      workflowId: this._currentWorkflowId,
+      currentNodeId: this._currentNodeId,
+      returnMap: options?.returnMap ?? [],
+      blackboard: [
+        ...this._currentBlackboard.getEntries(),
+      ] as BlackboardEntry[],
+    };
+    this._stack.unshift(frame);
+
+    // Switch active context to sub-workflow
+    this._currentWorkflowId = subWorkflow.id;
+    this._currentNodeId = subWorkflow.entry;
+    this._currentBlackboard = new ScopedBlackboard();
+
+    // Clear stale _skipInvocation — the consumer is intentionally pushing,
+    // so any flag left from a prior pop must not suppress declarative
+    // invocations in the child workflow.
+    this._skipInvocation = false;
+
+    // Apply inputMap: seed child blackboard with parent values
+    if (options?.inputMap && options.inputMap.length > 0) {
+      const source: BlackboardSource = {
+        workflowId: subWorkflow.id,
+        nodeId: '__push__',
+        stackDepth: this._stack.length,
+      };
+      const writes: { key: string; value: unknown }[] = [];
+      for (const mapping of options.inputMap) {
+        const value = parentReader.get(mapping.from);
+        if (value !== undefined) {
+          writes.push({ key: mapping.to, value });
+        }
+      }
+      if (writes.length > 0) {
+        const newEntries = this._currentBlackboard.append(writes, source);
+        this._emit('blackboard:write', {
+          entries: newEntries,
+          workflow: subWorkflow,
+        });
+      }
+    }
+
+    // Event order: workflow:push → node:enter (mirrors declarative push)
+    this._emit('workflow:push', { frame, workflow: subWorkflow });
+
+    const entryNode = subWorkflow.nodes[subWorkflow.entry]!;
+    this._emit('node:enter', { node: entryNode, workflow: subWorkflow });
+
+    return { status: 'invoked', workflow: subWorkflow, node: entryNode };
+  }
+
+  /**
+   * Programmatically pop the current sub-workflow off the call stack,
+   * applying the returnMap from the most recent {@link pushWorkflow} call.
+   *
+   * The engine returns to the **same node** it was at when pushWorkflow
+   * was called — no cycle issue since this is imperative, not graph-driven.
+   *
+   * @throws {EngineError} If called before init(), in completed/error
+   *   state, or if the stack is empty.
+   */
+  popWorkflow(): StepResult {
+    // -- Precondition guards ------------------------------------------------
+    if (
+      this._currentWorkflowId === null ||
+      this._currentNodeId === null ||
+      this._currentBlackboard === null
+    ) {
+      throw new EngineError('popWorkflow() called before init()');
+    }
+    if (this._status !== 'running' && this._status !== 'suspended') {
+      throw new EngineError(
+        `popWorkflow() called in invalid state: '${this._status}' — engine must be 'running' or 'suspended'`,
+      );
+    }
+    if (this._stack.length === 0) {
+      throw new EngineError(
+        'popWorkflow() called with empty stack — nothing to pop',
+      );
+    }
+
+    // Capture child state and pop frame
+    const childBlackboard = this._currentBlackboard;
+    const frame = this._stack.shift()!;
+
+    // Reconstruct parent blackboard from frozen snapshot
+    const parentBlackboard = new ScopedBlackboard(frame.blackboard);
+    const parentWorkflow = this._registry.get(frame.workflowId)!;
+    const returnSource: BlackboardSource = {
+      workflowId: frame.workflowId,
+      nodeId: frame.currentNodeId,
+      stackDepth: this._stack.length,
+    };
+
+    // Execute returnMap: copy child values → parent blackboard
+    for (const mapping of frame.returnMap) {
+      const childValue = childBlackboard.reader().get(mapping.childKey);
+      if (childValue !== undefined) {
+        const newEntries = parentBlackboard.append(
+          [{ key: mapping.parentKey, value: childValue }],
+          returnSource,
+        );
+        this._emit('blackboard:write', {
+          entries: newEntries,
+          workflow: parentWorkflow,
+        });
+      }
+    }
+
+    // Restore parent state — skip re-invocation on the next step()
+    this._currentWorkflowId = frame.workflowId;
+    this._currentNodeId = frame.currentNodeId;
+    this._currentBlackboard = parentBlackboard;
+    this._skipInvocation = true;
+
+    const invokingNode = parentWorkflow.nodes[frame.currentNodeId]!;
+
+    // Event order: workflow:pop → node:enter (mirrors automatic pop)
+    this._emit('workflow:pop', { frame, workflow: parentWorkflow });
+    this._emit('node:enter', { node: invokingNode, workflow: parentWorkflow });
+
+    return { status: 'popped', workflow: parentWorkflow, node: invokingNode };
   }
 
   // -------------------------------------------------------------------------

--- a/typescript/src/index.ts
+++ b/typescript/src/index.ts
@@ -67,6 +67,8 @@ export type {
   InitOptions,
   UnwindOptions,
   UnwindEvent,
+  InputMapping,
+  PushWorkflowOptions,
   EngineSnapshot,
   GuardRegistry,
   RestoreOptions,

--- a/typescript/src/push-pop.test.ts
+++ b/typescript/src/push-pop.test.ts
@@ -1,0 +1,739 @@
+import { describe, it, expect } from 'vitest';
+import { ReflexEngine, EngineError } from './engine';
+import { WorkflowRegistry } from './registry';
+import {
+  Workflow,
+  Node,
+  DecisionAgent,
+  DecisionContext,
+  Decision,
+  ReturnMapping,
+} from './types';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function node(id: string): Node {
+  return { id, spec: {} };
+}
+
+function invocationNode(
+  id: string,
+  workflowId: string,
+  returnMap: ReturnMapping[] = [],
+): Node {
+  return { id, spec: {}, invokes: { workflowId, returnMap } };
+}
+
+function makeAgent(
+  resolve: (ctx: DecisionContext) => Promise<Decision>,
+): DecisionAgent {
+  return { resolve };
+}
+
+// ---------------------------------------------------------------------------
+// Workflow Fixtures
+// ---------------------------------------------------------------------------
+
+/** Parent workflow: INIT → WORK → END */
+function parentWorkflow(): Workflow {
+  return {
+    id: 'parent',
+    entry: 'P_INIT',
+    nodes: {
+      P_INIT: node('P_INIT'),
+      P_WORK: node('P_WORK'),
+      P_END: node('P_END'),
+    },
+    edges: [
+      { id: 'e-p-init-work', from: 'P_INIT', to: 'P_WORK', event: 'NEXT' },
+      { id: 'e-p-work-end', from: 'P_WORK', to: 'P_END', event: 'NEXT' },
+    ],
+  };
+}
+
+/** Child workflow: ENTRY → FINISH (terminal) */
+function childWorkflow(): Workflow {
+  return {
+    id: 'child',
+    entry: 'C_ENTRY',
+    nodes: {
+      C_ENTRY: node('C_ENTRY'),
+      C_FINISH: node('C_FINISH'),
+    },
+    edges: [
+      { id: 'e-c-entry-finish', from: 'C_ENTRY', to: 'C_FINISH', event: 'NEXT' },
+    ],
+  };
+}
+
+/** Parent with a declarative invocation node: INIT → INVOKE(child) → END */
+function parentWithInvoke(): Workflow {
+  return {
+    id: 'parent-inv',
+    entry: 'PI_INIT',
+    nodes: {
+      PI_INIT: node('PI_INIT'),
+      PI_INVOKE: invocationNode('PI_INVOKE', 'child', [
+        { parentKey: 'result', childKey: 'output' },
+      ]),
+      PI_END: node('PI_END'),
+    },
+    edges: [
+      { id: 'e-pi-init-invoke', from: 'PI_INIT', to: 'PI_INVOKE', event: 'NEXT' },
+      { id: 'e-pi-invoke-end', from: 'PI_INVOKE', to: 'PI_END', event: 'NEXT' },
+    ],
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Setup helper — creates engine, registers workflows, inits parent
+// ---------------------------------------------------------------------------
+
+async function setup(opts?: {
+  agent?: DecisionAgent;
+  workflows?: Workflow[];
+  initWorkflow?: string;
+}) {
+  const registry = new WorkflowRegistry();
+  const workflows = opts?.workflows ?? [parentWorkflow(), childWorkflow()];
+  for (const w of workflows) {
+    registry.register(w);
+  }
+
+  const agent =
+    opts?.agent ??
+    makeAgent(async () => ({ type: 'suspend', reason: 'waiting' }));
+
+  const engine = new ReflexEngine(registry, agent);
+  await engine.init(opts?.initWorkflow ?? 'parent');
+  return { engine, registry };
+}
+
+// ---------------------------------------------------------------------------
+// pushWorkflow — basic push
+// ---------------------------------------------------------------------------
+
+describe('pushWorkflow — basic push', () => {
+  it('switches to sub-workflow entry node', async () => {
+    const { engine } = await setup();
+    engine.pushWorkflow('child');
+    expect(engine.currentWorkflow()!.id).toBe('child');
+    expect(engine.currentNode()!.id).toBe('C_ENTRY');
+  });
+
+  it('grows the stack by 1', async () => {
+    const { engine } = await setup();
+    expect(engine.stack().length).toBe(0);
+    engine.pushWorkflow('child');
+    expect(engine.stack().length).toBe(1);
+  });
+
+  it('frame at index 0 has correct workflowId and currentNodeId', async () => {
+    const { engine } = await setup();
+    engine.pushWorkflow('child');
+    const frame = engine.stack()[0];
+    expect(frame.workflowId).toBe('parent');
+    expect(frame.currentNodeId).toBe('P_INIT');
+  });
+
+  it('emits workflow:push event', async () => {
+    const { engine } = await setup();
+    const events: unknown[] = [];
+    engine.on('workflow:push', (p) => events.push(p));
+    engine.pushWorkflow('child');
+    expect(events.length).toBe(1);
+  });
+
+  it('emits node:enter for sub-workflow entry node after workflow:push', async () => {
+    const { engine } = await setup();
+    const order: string[] = [];
+    engine.on('workflow:push', () => order.push('workflow:push'));
+    engine.on('node:enter', (p: any) => order.push(`node:enter:${p.node.id}`));
+    engine.pushWorkflow('child');
+    expect(order).toEqual(['workflow:push', 'node:enter:C_ENTRY']);
+  });
+
+  it('returns { status: invoked } with correct workflow and node', async () => {
+    const { engine } = await setup();
+    const result = engine.pushWorkflow('child');
+    expect(result.status).toBe('invoked');
+    if (result.status === 'invoked') {
+      expect(result.workflow.id).toBe('child');
+      expect(result.node.id).toBe('C_ENTRY');
+    }
+  });
+
+  it('does not set _skipInvocation (snapshot shows false)', async () => {
+    const { engine } = await setup();
+    engine.pushWorkflow('child');
+    const snap = engine.snapshot();
+    expect(snap.skipInvocation).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// pushWorkflow — inputMap
+// ---------------------------------------------------------------------------
+
+describe('pushWorkflow — inputMap', () => {
+  it('seeds child blackboard with mapped parent value', async () => {
+    const agent = makeAgent(async () => ({
+      type: 'advance',
+      edge: 'e-p-init-work',
+      writes: [{ key: 'Color', value: 'Red' }],
+    }));
+    const { engine } = await setup({ agent });
+    // Write a value to parent blackboard
+    await engine.step(); // advance P_INIT → P_WORK, writes Color=Red
+
+    engine.pushWorkflow('child', {
+      inputMap: [{ from: 'Color', to: 'ParentColor' }],
+    });
+
+    expect(engine.blackboard().get('ParentColor')).toBe('Red');
+  });
+
+  it('emits blackboard:write for seeded entries', async () => {
+    const agent = makeAgent(async () => ({
+      type: 'advance',
+      edge: 'e-p-init-work',
+      writes: [{ key: 'Color', value: 'Red' }],
+    }));
+    const { engine } = await setup({ agent });
+    await engine.step();
+
+    const bbEvents: unknown[] = [];
+    engine.on('blackboard:write', (p) => bbEvents.push(p));
+
+    engine.pushWorkflow('child', {
+      inputMap: [{ from: 'Color', to: 'ParentColor' }],
+    });
+
+    expect(bbEvents.length).toBe(1);
+  });
+
+  it('seeded value is in child local scope, not via parent scope chain', async () => {
+    const agent = makeAgent(async () => ({
+      type: 'advance',
+      edge: 'e-p-init-work',
+      writes: [{ key: 'Color', value: 'Red' }],
+    }));
+    const { engine } = await setup({ agent });
+    await engine.step();
+
+    engine.pushWorkflow('child', {
+      inputMap: [{ from: 'Color', to: 'ParentColor' }],
+    });
+
+    // Should be in local scope
+    const localEntries = engine.blackboard().local();
+    expect(localEntries.some((e) => e.key === 'ParentColor')).toBe(true);
+  });
+
+  it('unmapped parent keys are still readable via scope chain', async () => {
+    const agent = makeAgent(async () => ({
+      type: 'advance',
+      edge: 'e-p-init-work',
+      writes: [{ key: 'Color', value: 'Red' }, { key: 'Size', value: 'Large' }],
+    }));
+    const { engine } = await setup({ agent });
+    await engine.step();
+
+    engine.pushWorkflow('child', {
+      inputMap: [{ from: 'Color', to: 'ParentColor' }],
+    });
+
+    // Size was not mapped but should be readable via scope chain
+    expect(engine.blackboard().get('Size')).toBe('Large');
+  });
+
+  it('silently skips input keys not found in parent', async () => {
+    const { engine } = await setup();
+    // No writes to parent blackboard — 'Missing' doesn't exist
+    const result = engine.pushWorkflow('child', {
+      inputMap: [{ from: 'Missing', to: 'Target' }],
+    });
+
+    expect(result.status).toBe('invoked');
+    expect(engine.blackboard().get('Target')).toBeUndefined();
+  });
+
+  it('batches multiple inputMap entries in a single blackboard:write', async () => {
+    const agent = makeAgent(async () => ({
+      type: 'advance',
+      edge: 'e-p-init-work',
+      writes: [{ key: 'A', value: 1 }, { key: 'B', value: 2 }],
+    }));
+    const { engine } = await setup({ agent });
+    await engine.step();
+
+    const bbEvents: any[] = [];
+    engine.on('blackboard:write', (p) => bbEvents.push(p));
+
+    engine.pushWorkflow('child', {
+      inputMap: [{ from: 'A', to: 'X' }, { from: 'B', to: 'Y' }],
+    });
+
+    expect(bbEvents.length).toBe(1);
+    expect(bbEvents[0].entries.length).toBe(2);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// pushWorkflow — returnMap
+// ---------------------------------------------------------------------------
+
+describe('pushWorkflow — returnMap', () => {
+  it('returnMap is applied on pop', async () => {
+    const agent = makeAgent(async (ctx) => {
+      if (ctx.node.id === 'C_ENTRY') {
+        return {
+          type: 'advance',
+          edge: 'e-c-entry-finish',
+          writes: [{ key: 'output', value: 'hello' }],
+        };
+      }
+      return { type: 'suspend', reason: 'waiting' };
+    });
+    const { engine } = await setup({ agent });
+
+    engine.pushWorkflow('child', {
+      returnMap: [{ parentKey: 'result', childKey: 'output' }],
+    });
+
+    // Advance child to terminal
+    await engine.step(); // C_ENTRY → C_FINISH, writes output=hello
+
+    engine.popWorkflow();
+
+    expect(engine.blackboard().get('result')).toBe('hello');
+  });
+
+  it('default returnMap is empty — no writes on pop', async () => {
+    const { engine } = await setup();
+    engine.pushWorkflow('child'); // no returnMap
+
+    const bbEvents: unknown[] = [];
+    engine.on('blackboard:write', (p) => bbEvents.push(p));
+
+    engine.popWorkflow();
+
+    expect(bbEvents.length).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// popWorkflow — basic pop
+// ---------------------------------------------------------------------------
+
+describe('popWorkflow — basic pop', () => {
+  it('restores parent workflow and node', async () => {
+    const { engine } = await setup();
+    engine.pushWorkflow('child');
+    engine.popWorkflow();
+    expect(engine.currentWorkflow()!.id).toBe('parent');
+    expect(engine.currentNode()!.id).toBe('P_INIT');
+  });
+
+  it('shrinks the stack by 1', async () => {
+    const { engine } = await setup();
+    engine.pushWorkflow('child');
+    expect(engine.stack().length).toBe(1);
+    engine.popWorkflow();
+    expect(engine.stack().length).toBe(0);
+  });
+
+  it('emits workflow:pop event', async () => {
+    const { engine } = await setup();
+    engine.pushWorkflow('child');
+
+    const events: unknown[] = [];
+    engine.on('workflow:pop', (p) => events.push(p));
+    engine.popWorkflow();
+
+    expect(events.length).toBe(1);
+  });
+
+  it('emits node:enter for restored parent node after workflow:pop', async () => {
+    const { engine } = await setup();
+    engine.pushWorkflow('child');
+
+    const order: string[] = [];
+    engine.on('workflow:pop', () => order.push('workflow:pop'));
+    engine.on('node:enter', (p: any) => order.push(`node:enter:${p.node.id}`));
+    engine.popWorkflow();
+
+    expect(order).toEqual(['workflow:pop', 'node:enter:P_INIT']);
+  });
+
+  it('returns { status: popped } with correct workflow and node', async () => {
+    const { engine } = await setup();
+    engine.pushWorkflow('child');
+    const result = engine.popWorkflow();
+
+    expect(result.status).toBe('popped');
+    if (result.status === 'popped') {
+      expect(result.workflow.id).toBe('parent');
+      expect(result.node.id).toBe('P_INIT');
+    }
+  });
+
+  it('sets _skipInvocation to true after pop', async () => {
+    const { engine } = await setup();
+    engine.pushWorkflow('child');
+    engine.popWorkflow();
+    const snap = engine.snapshot();
+    expect(snap.skipInvocation).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// popWorkflow — returnMap execution
+// ---------------------------------------------------------------------------
+
+describe('popWorkflow — returnMap execution', () => {
+  it('child value appears in parent blackboard under parentKey', async () => {
+    const agent = makeAgent(async (ctx) => {
+      if (ctx.node.id === 'C_ENTRY') {
+        return {
+          type: 'advance',
+          edge: 'e-c-entry-finish',
+          writes: [{ key: 'childResult', value: 42 }],
+        };
+      }
+      return { type: 'suspend', reason: 'waiting' };
+    });
+    const { engine } = await setup({ agent });
+
+    engine.pushWorkflow('child', {
+      returnMap: [{ parentKey: 'answer', childKey: 'childResult' }],
+    });
+
+    await engine.step(); // advance in child, writes childResult=42
+    engine.popWorkflow();
+
+    expect(engine.blackboard().get('answer')).toBe(42);
+  });
+
+  it('missing childKey is gracefully skipped', async () => {
+    const { engine } = await setup();
+    engine.pushWorkflow('child', {
+      returnMap: [{ parentKey: 'answer', childKey: 'nonexistent' }],
+    });
+
+    const bbEvents: unknown[] = [];
+    engine.on('blackboard:write', (p) => bbEvents.push(p));
+
+    engine.popWorkflow();
+
+    expect(bbEvents.length).toBe(0);
+    expect(engine.blackboard().get('answer')).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// _skipInvocation behavior after popWorkflow
+// ---------------------------------------------------------------------------
+
+describe('_skipInvocation behavior after popWorkflow', () => {
+  it('restored parent node with invokes: next step() runs agent, not invocation', async () => {
+    const agentCalls: string[] = [];
+    const agent = makeAgent(async (ctx) => {
+      agentCalls.push(ctx.node.id);
+      if (ctx.node.id === 'PI_INIT') {
+        return { type: 'advance', edge: 'e-pi-init-invoke', writes: [] };
+      }
+      if (ctx.node.id === 'PI_INVOKE') {
+        return { type: 'advance', edge: 'e-pi-invoke-end', writes: [] };
+      }
+      return { type: 'suspend', reason: 'waiting' };
+    });
+
+    const registry = new WorkflowRegistry();
+    registry.register(parentWithInvoke());
+    registry.register(childWorkflow());
+    const engine = new ReflexEngine(registry, agent);
+    await engine.init('parent-inv');
+
+    // Advance to the invocation node
+    await engine.step(); // PI_INIT → PI_INVOKE (agent called for PI_INIT)
+
+    // Now at PI_INVOKE — instead of letting declarative invocation fire,
+    // do a manual push/pop cycle
+    engine.pushWorkflow('child');
+    engine.popWorkflow();
+
+    // Next step should run the agent at PI_INVOKE (skip re-invocation)
+    agentCalls.length = 0;
+    await engine.step(); // should call agent for PI_INVOKE, advance to PI_END
+
+    expect(agentCalls).toContain('PI_INVOKE');
+    expect(engine.currentNode()!.id).toBe('PI_END');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Full round-trip: push → step in child → pop
+// ---------------------------------------------------------------------------
+
+describe('full round-trip: push → step in child → pop', () => {
+  it('push child, advance through it, pop, resume parent', async () => {
+    const agent = makeAgent(async (ctx) => {
+      if (ctx.node.id === 'P_INIT') {
+        return { type: 'advance', edge: 'e-p-init-work', writes: [] };
+      }
+      if (ctx.node.id === 'C_ENTRY') {
+        return {
+          type: 'advance',
+          edge: 'e-c-entry-finish',
+          writes: [{ key: 'output', value: 'done' }],
+        };
+      }
+      return { type: 'suspend', reason: 'waiting' };
+    });
+    const { engine } = await setup({ agent });
+
+    // Advance parent to P_WORK
+    await engine.step();
+    expect(engine.currentNode()!.id).toBe('P_WORK');
+
+    // Push child workflow with returnMap
+    engine.pushWorkflow('child', {
+      returnMap: [{ parentKey: 'childOutput', childKey: 'output' }],
+    });
+    expect(engine.currentWorkflow()!.id).toBe('child');
+
+    // Step through child
+    await engine.step(); // C_ENTRY → C_FINISH
+    expect(engine.currentNode()!.id).toBe('C_FINISH');
+
+    // Pop back to parent
+    engine.popWorkflow();
+    expect(engine.currentWorkflow()!.id).toBe('parent');
+    expect(engine.currentNode()!.id).toBe('P_WORK');
+    expect(engine.blackboard().get('childOutput')).toBe('done');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Coexistence with declarative node.invokes
+// ---------------------------------------------------------------------------
+
+describe('coexistence with declarative node.invokes', () => {
+  it('declarative invocation still triggers after a manual push/pop', async () => {
+    const agent = makeAgent(async (ctx) => {
+      if (ctx.node.id === 'PI_INIT') {
+        return { type: 'advance', edge: 'e-pi-init-invoke', writes: [] };
+      }
+      if (ctx.node.id === 'C_ENTRY') {
+        return { type: 'advance', edge: 'e-c-entry-finish', writes: [] };
+      }
+      if (ctx.node.id === 'C_FINISH') {
+        return { type: 'complete', writes: [{ key: 'output', value: 'v1' }] };
+      }
+      if (ctx.node.id === 'PI_INVOKE') {
+        return { type: 'advance', edge: 'e-pi-invoke-end', writes: [] };
+      }
+      return { type: 'suspend', reason: 'waiting' };
+    });
+
+    const registry = new WorkflowRegistry();
+    registry.register(parentWithInvoke());
+    registry.register(childWorkflow());
+    const engine = new ReflexEngine(registry, agent);
+    await engine.init('parent-inv');
+
+    // Manual push/pop at entry node (before reaching the invocation node)
+    engine.pushWorkflow('child');
+    engine.popWorkflow();
+
+    // Now advance to PI_INVOKE — the declarative invocation should fire
+    await engine.step(); // agent resolves PI_INIT, advances to PI_INVOKE
+    const stepResult = await engine.step(); // PI_INVOKE has invokes → auto push
+
+    expect(stepResult.status).toBe('invoked');
+    expect(engine.currentWorkflow()!.id).toBe('child');
+  });
+
+  it('manual push clears _skipInvocation so child invocations work', async () => {
+    // After an automatic pop, _skipInvocation is true. If we then manually
+    // push into a workflow whose entry node has invokes, the flag must be
+    // cleared so the declarative invocation fires.
+    const childWithInvoke: Workflow = {
+      id: 'child-inv',
+      entry: 'CI_ENTRY',
+      nodes: {
+        CI_ENTRY: invocationNode('CI_ENTRY', 'child'),
+        CI_END: node('CI_END'),
+      },
+      edges: [
+        { id: 'e-ci-entry-end', from: 'CI_ENTRY', to: 'CI_END', event: 'NEXT' },
+      ],
+    };
+
+    const agent = makeAgent(async (ctx) => {
+      if (ctx.node.id === 'C_ENTRY') {
+        return { type: 'advance', edge: 'e-c-entry-finish', writes: [] };
+      }
+      if (ctx.node.id === 'C_FINISH') {
+        return { type: 'complete', writes: [] };
+      }
+      return { type: 'suspend', reason: 'waiting' };
+    });
+
+    const registry = new WorkflowRegistry();
+    registry.register(parentWorkflow());
+    registry.register(childWorkflow());
+    registry.register(childWithInvoke);
+    const engine = new ReflexEngine(registry, agent);
+    await engine.init('parent');
+
+    // Simulate a prior pop that set _skipInvocation = true
+    engine.pushWorkflow('child');
+    engine.popWorkflow();
+    expect(engine.snapshot().skipInvocation).toBe(true);
+
+    // Now push into child-inv whose entry has invokes
+    engine.pushWorkflow('child-inv');
+    expect(engine.snapshot().skipInvocation).toBe(false);
+
+    // Next step should trigger the declarative invocation at CI_ENTRY
+    const result = await engine.step();
+    expect(result.status).toBe('invoked');
+    expect(engine.currentWorkflow()!.id).toBe('child');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Suspended-state behavior
+// ---------------------------------------------------------------------------
+
+describe('suspended-state behavior', () => {
+  it('pushWorkflow works when status is suspended', async () => {
+    const agent = makeAgent(async () => ({
+      type: 'suspend',
+      reason: 'awaiting input',
+    }));
+    const { engine } = await setup({ agent });
+
+    // Suspend the engine
+    await engine.step();
+    expect(engine.status()).toBe('suspended');
+
+    // Push should work
+    const result = engine.pushWorkflow('child');
+    expect(result.status).toBe('invoked');
+    expect(engine.currentWorkflow()!.id).toBe('child');
+  });
+
+  it('popWorkflow works when status is suspended', async () => {
+    const agent = makeAgent(async () => ({
+      type: 'suspend',
+      reason: 'awaiting input',
+    }));
+    const { engine } = await setup({ agent });
+
+    // Push then suspend in child
+    engine.pushWorkflow('child');
+    await engine.step();
+    expect(engine.status()).toBe('suspended');
+
+    // Pop should work
+    const result = engine.popWorkflow();
+    expect(result.status).toBe('popped');
+    expect(engine.currentWorkflow()!.id).toBe('parent');
+  });
+
+  it('engine status is preserved across push/pop', async () => {
+    const agent = makeAgent(async () => ({
+      type: 'suspend',
+      reason: 'awaiting input',
+    }));
+    const { engine } = await setup({ agent });
+
+    // Suspend the engine
+    await engine.step();
+    expect(engine.status()).toBe('suspended');
+
+    // Push and pop — status should remain suspended
+    engine.pushWorkflow('child');
+    expect(engine.status()).toBe('suspended');
+    engine.popWorkflow();
+    expect(engine.status()).toBe('suspended');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Preconditions
+// ---------------------------------------------------------------------------
+
+describe('preconditions', () => {
+  it('pushWorkflow throws before init()', () => {
+    const registry = new WorkflowRegistry();
+    registry.register(parentWorkflow());
+    registry.register(childWorkflow());
+    const agent = makeAgent(async () => ({ type: 'suspend', reason: '' }));
+    const engine = new ReflexEngine(registry, agent);
+
+    expect(() => engine.pushWorkflow('child')).toThrow(EngineError);
+  });
+
+  it('pushWorkflow throws for unregistered workflowId', async () => {
+    const { engine } = await setup();
+    expect(() => engine.pushWorkflow('nonexistent')).toThrow(EngineError);
+  });
+
+  it('pushWorkflow throws when status is completed', async () => {
+    const agent = makeAgent(async () => ({ type: 'complete', writes: [] }));
+    // Single-node workflow that completes immediately
+    const singleNode: Workflow = {
+      id: 'single',
+      entry: 'ONLY',
+      nodes: { ONLY: node('ONLY') },
+      edges: [],
+    };
+    const registry = new WorkflowRegistry();
+    registry.register(singleNode);
+    registry.register(childWorkflow());
+    const engine = new ReflexEngine(registry, agent);
+    await engine.init('single');
+    await engine.step(); // completes
+
+    expect(engine.status()).toBe('completed');
+    expect(() => engine.pushWorkflow('child')).toThrow(EngineError);
+  });
+
+  it('popWorkflow throws before init()', () => {
+    const registry = new WorkflowRegistry();
+    registry.register(parentWorkflow());
+    const agent = makeAgent(async () => ({ type: 'suspend', reason: '' }));
+    const engine = new ReflexEngine(registry, agent);
+
+    expect(() => engine.popWorkflow()).toThrow(EngineError);
+  });
+
+  it('popWorkflow throws when stack is empty', async () => {
+    const { engine } = await setup();
+    expect(() => engine.popWorkflow()).toThrow(EngineError);
+  });
+
+  it('popWorkflow throws when status is completed', async () => {
+    const agent = makeAgent(async () => ({ type: 'complete', writes: [] }));
+    const singleNode: Workflow = {
+      id: 'single',
+      entry: 'ONLY',
+      nodes: { ONLY: node('ONLY') },
+      edges: [],
+    };
+    const registry = new WorkflowRegistry();
+    registry.register(singleNode);
+    const engine = new ReflexEngine(registry, agent);
+    await engine.init('single');
+    await engine.step();
+
+    expect(engine.status()).toBe('completed');
+    expect(() => engine.popWorkflow()).toThrow(EngineError);
+  });
+});

--- a/typescript/src/types.ts
+++ b/typescript/src/types.ts
@@ -30,6 +30,34 @@ export interface ReturnMapping {
 }
 
 // ---------------------------------------------------------------------------
+// 2.14 InputMapping (imperative push/pop)
+// ---------------------------------------------------------------------------
+
+/**
+ * Maps a parent blackboard key to a child blackboard key at push time.
+ * Used by {@link ReflexEngine.pushWorkflow | pushWorkflow()} to seed the
+ * child workflow's local blackboard with values from the parent scope.
+ *
+ * This is the inverse of {@link ReturnMapping}: values flow down via
+ * inputMap at push time, and up via returnMap at pop time.
+ */
+export interface InputMapping {
+  from: string;
+  to: string;
+}
+
+/**
+ * Options for {@link ReflexEngine.pushWorkflow | pushWorkflow()}.
+ *
+ * Both fields are optional — a bare `pushWorkflow(id)` call pushes
+ * with no input seeding and no return propagation.
+ */
+export interface PushWorkflowOptions {
+  returnMap?: ReturnMapping[];
+  inputMap?: InputMapping[];
+}
+
+// ---------------------------------------------------------------------------
 // 2.4 InvocationSpec
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Closes #112

Adds public `pushWorkflow(workflowId, options?)` and `popWorkflow()` methods to `ReflexEngine` for programmatic sub-workflow invocation, complementing the existing declarative `node.invokes` mechanism.

- **`pushWorkflow`** — saves current state as a StackFrame, switches to sub-workflow entry node, optionally seeds child blackboard via `inputMap`, emits `workflow:push` + `node:enter`
- **`popWorkflow`** — applies `returnMap`, restores parent state, sets `_skipInvocation`, emits `workflow:pop` + `node:enter`
- **`inputMap`** — parent→child value mapping at push time (additive seeding, not parent-key isolation)
- Both methods are **synchronous** (no agent resolution) — the issue described `Promise<StepResult>` conceptually but the implementation returns `StepResult` directly since no async work occurs
- Coexists with declarative `node.invokes` — existing behavior unchanged

### New types
- `InputMapping { from: string; to: string }`
- `PushWorkflowOptions { returnMap?: ReturnMapping[]; inputMap?: InputMapping[] }`

## Test plan

- [x] 36 new tests in `push-pop.test.ts` covering:
  - Basic push (state switch, stack growth, events, return value)
  - inputMap seeding (batched writes, scope chain, silent skip for missing keys)
  - returnMap propagation on pop
  - Basic pop (state restore, stack shrink, events, return value)
  - `_skipInvocation` behavior (cleared on push, set on pop)
  - Full round-trip (push → step in child → pop → resume parent)
  - Coexistence with declarative `node.invokes`
  - Suspended-state behavior (primary use case: user-triggered branching)
  - Precondition errors (before init, empty stack, completed state, unregistered workflow)
- [x] All 443 tests pass
- [x] Type check clean